### PR TITLE
feat: Add dual login

### DIFF
--- a/src/lib/auth/allowed.test.ts
+++ b/src/lib/auth/allowed.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+const ORIGINAL = process.env.AUTH_ALLOWED_DID;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.AUTH_ALLOWED_DID;
+  else process.env.AUTH_ALLOWED_DID = ORIGINAL;
+});
+
+async function loadFresh() {
+  // env() reads process.env at call time, so re-import isn't required, but
+  // keep this helper for clarity if that changes.
+  return await import("./allowed");
+}
+
+describe("getAllowedDids", () => {
+  it("returns an empty array when the env var is not set", async () => {
+    delete process.env.AUTH_ALLOWED_DID;
+    const { getAllowedDids } = await loadFresh();
+    expect(getAllowedDids()).toEqual([]);
+  });
+
+  it("returns an empty array when the env var is empty", async () => {
+    process.env.AUTH_ALLOWED_DID = "";
+    const { getAllowedDids } = await loadFresh();
+    expect(getAllowedDids()).toEqual([]);
+  });
+
+  it("returns a single DID", async () => {
+    process.env.AUTH_ALLOWED_DID = "did:plc:abc";
+    const { getAllowedDids } = await loadFresh();
+    expect(getAllowedDids()).toEqual(["did:plc:abc"]);
+  });
+
+  it("returns multiple DIDs from a comma-separated list", async () => {
+    process.env.AUTH_ALLOWED_DID = "did:plc:abc,did:plc:def";
+    const { getAllowedDids } = await loadFresh();
+    expect(getAllowedDids()).toEqual(["did:plc:abc", "did:plc:def"]);
+  });
+
+  it("trims whitespace and drops empty entries", async () => {
+    process.env.AUTH_ALLOWED_DID = " did:plc:abc , ,did:plc:def , ";
+    const { getAllowedDids } = await loadFresh();
+    expect(getAllowedDids()).toEqual(["did:plc:abc", "did:plc:def"]);
+  });
+});
+
+describe("isAllowedDid", () => {
+  it("returns false for null/undefined/empty input", async () => {
+    process.env.AUTH_ALLOWED_DID = "did:plc:abc";
+    const { isAllowedDid } = await loadFresh();
+    expect(isAllowedDid(null)).toBe(false);
+    expect(isAllowedDid(undefined)).toBe(false);
+    expect(isAllowedDid("")).toBe(false);
+  });
+
+  it("returns false when no DIDs are configured", async () => {
+    delete process.env.AUTH_ALLOWED_DID;
+    const { isAllowedDid } = await loadFresh();
+    expect(isAllowedDid("did:plc:abc")).toBe(false);
+  });
+
+  it("returns true when the DID matches the single configured DID", async () => {
+    process.env.AUTH_ALLOWED_DID = "did:plc:abc";
+    const { isAllowedDid } = await loadFresh();
+    expect(isAllowedDid("did:plc:abc")).toBe(true);
+    expect(isAllowedDid("did:plc:other")).toBe(false);
+  });
+
+  it("returns true for any DID in the comma-separated list", async () => {
+    process.env.AUTH_ALLOWED_DID = "did:plc:abc, did:plc:def";
+    const { isAllowedDid } = await loadFresh();
+    expect(isAllowedDid("did:plc:abc")).toBe(true);
+    expect(isAllowedDid("did:plc:def")).toBe(true);
+    expect(isAllowedDid("did:plc:nope")).toBe(false);
+  });
+});

--- a/src/lib/auth/allowed.test.ts
+++ b/src/lib/auth/allowed.test.ts
@@ -1,77 +1,41 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-const ORIGINAL = process.env.AUTH_ALLOWED_DID;
-
-afterEach(() => {
-  if (ORIGINAL === undefined) delete process.env.AUTH_ALLOWED_DID;
-  else process.env.AUTH_ALLOWED_DID = ORIGINAL;
-});
-
-async function loadFresh() {
-  // env() reads process.env at call time, so re-import isn't required, but
-  // keep this helper for clarity if that changes.
-  return await import("./allowed");
-}
+import { getAllowedDids } from "./allowed";
 
 describe("getAllowedDids", () => {
-  it("returns an empty array when the env var is not set", async () => {
-    delete process.env.AUTH_ALLOWED_DID;
-    const { getAllowedDids } = await loadFresh();
+  it("returns an empty array when the env var is not set", () => {
+    vi.stubEnv("AUTH_ALLOWED_DID", undefined as unknown as string);
     expect(getAllowedDids()).toEqual([]);
+    vi.unstubAllEnvs();
   });
 
-  it("returns an empty array when the env var is empty", async () => {
-    process.env.AUTH_ALLOWED_DID = "";
-    const { getAllowedDids } = await loadFresh();
+  it("returns an empty array when the env var is empty", () => {
+    vi.stubEnv("AUTH_ALLOWED_DID", "");
     expect(getAllowedDids()).toEqual([]);
+    vi.unstubAllEnvs();
   });
 
-  it("returns a single DID", async () => {
-    process.env.AUTH_ALLOWED_DID = "did:plc:abc";
-    const { getAllowedDids } = await loadFresh();
+  it("returns an empty array when the env var is whitespace/commas only", () => {
+    vi.stubEnv("AUTH_ALLOWED_DID", " , ,, ");
+    expect(getAllowedDids()).toEqual([]);
+    vi.unstubAllEnvs();
+  });
+
+  it("returns a single DID", () => {
+    vi.stubEnv("AUTH_ALLOWED_DID", "did:plc:abc");
     expect(getAllowedDids()).toEqual(["did:plc:abc"]);
+    vi.unstubAllEnvs();
   });
 
-  it("returns multiple DIDs from a comma-separated list", async () => {
-    process.env.AUTH_ALLOWED_DID = "did:plc:abc,did:plc:def";
-    const { getAllowedDids } = await loadFresh();
+  it("returns multiple DIDs from a comma-separated list", () => {
+    vi.stubEnv("AUTH_ALLOWED_DID", "did:plc:abc,did:plc:def");
     expect(getAllowedDids()).toEqual(["did:plc:abc", "did:plc:def"]);
+    vi.unstubAllEnvs();
   });
 
-  it("trims whitespace and drops empty entries", async () => {
-    process.env.AUTH_ALLOWED_DID = " did:plc:abc , ,did:plc:def , ";
-    const { getAllowedDids } = await loadFresh();
+  it("trims whitespace and drops empty entries", () => {
+    vi.stubEnv("AUTH_ALLOWED_DID", " did:plc:abc , ,did:plc:def , ");
     expect(getAllowedDids()).toEqual(["did:plc:abc", "did:plc:def"]);
-  });
-});
-
-describe("isAllowedDid", () => {
-  it("returns false for null/undefined/empty input", async () => {
-    process.env.AUTH_ALLOWED_DID = "did:plc:abc";
-    const { isAllowedDid } = await loadFresh();
-    expect(isAllowedDid(null)).toBe(false);
-    expect(isAllowedDid(undefined)).toBe(false);
-    expect(isAllowedDid("")).toBe(false);
-  });
-
-  it("returns false when no DIDs are configured", async () => {
-    delete process.env.AUTH_ALLOWED_DID;
-    const { isAllowedDid } = await loadFresh();
-    expect(isAllowedDid("did:plc:abc")).toBe(false);
-  });
-
-  it("returns true when the DID matches the single configured DID", async () => {
-    process.env.AUTH_ALLOWED_DID = "did:plc:abc";
-    const { isAllowedDid } = await loadFresh();
-    expect(isAllowedDid("did:plc:abc")).toBe(true);
-    expect(isAllowedDid("did:plc:other")).toBe(false);
-  });
-
-  it("returns true for any DID in the comma-separated list", async () => {
-    process.env.AUTH_ALLOWED_DID = "did:plc:abc, did:plc:def";
-    const { isAllowedDid } = await loadFresh();
-    expect(isAllowedDid("did:plc:abc")).toBe(true);
-    expect(isAllowedDid("did:plc:def")).toBe(true);
-    expect(isAllowedDid("did:plc:nope")).toBe(false);
+    vi.unstubAllEnvs();
   });
 });

--- a/src/lib/auth/allowed.test.ts
+++ b/src/lib/auth/allowed.test.ts
@@ -1,41 +1,39 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getAllowedDids } from "./allowed";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("getAllowedDids", () => {
   it("returns an empty array when the env var is not set", () => {
     vi.stubEnv("AUTH_ALLOWED_DID", undefined as unknown as string);
     expect(getAllowedDids()).toEqual([]);
-    vi.unstubAllEnvs();
   });
 
   it("returns an empty array when the env var is empty", () => {
     vi.stubEnv("AUTH_ALLOWED_DID", "");
     expect(getAllowedDids()).toEqual([]);
-    vi.unstubAllEnvs();
   });
 
   it("returns an empty array when the env var is whitespace/commas only", () => {
     vi.stubEnv("AUTH_ALLOWED_DID", " , ,, ");
     expect(getAllowedDids()).toEqual([]);
-    vi.unstubAllEnvs();
   });
 
   it("returns a single DID", () => {
     vi.stubEnv("AUTH_ALLOWED_DID", "did:plc:abc");
     expect(getAllowedDids()).toEqual(["did:plc:abc"]);
-    vi.unstubAllEnvs();
   });
 
   it("returns multiple DIDs from a comma-separated list", () => {
     vi.stubEnv("AUTH_ALLOWED_DID", "did:plc:abc,did:plc:def");
     expect(getAllowedDids()).toEqual(["did:plc:abc", "did:plc:def"]);
-    vi.unstubAllEnvs();
   });
 
   it("trims whitespace and drops empty entries", () => {
     vi.stubEnv("AUTH_ALLOWED_DID", " did:plc:abc , ,did:plc:def , ");
     expect(getAllowedDids()).toEqual(["did:plc:abc", "did:plc:def"]);
-    vi.unstubAllEnvs();
   });
 });

--- a/src/lib/auth/allowed.ts
+++ b/src/lib/auth/allowed.ts
@@ -1,0 +1,20 @@
+import { env } from "@lib/env";
+
+/**
+ * Returns the list of DIDs allowed to log in.
+ *
+ * Reads `AUTH_ALLOWED_DID`, which may contain a single DID or a
+ * comma-separated list of DIDs (whitespace ignored, empty entries dropped).
+ */
+export function getAllowedDids(): string[] {
+  const raw = env("AUTH_ALLOWED_DID") ?? "";
+  return raw
+    .split(",")
+    .map((d) => d.trim())
+    .filter(Boolean);
+}
+
+export function isAllowedDid(did: string | undefined | null): boolean {
+  if (!did) return false;
+  return getAllowedDids().includes(did);
+}

--- a/src/lib/auth/allowed.ts
+++ b/src/lib/auth/allowed.ts
@@ -5,6 +5,10 @@ import { env } from "@lib/env";
  *
  * Reads `AUTH_ALLOWED_DID`, which may contain a single DID or a
  * comma-separated list of DIDs (whitespace ignored, empty entries dropped).
+ *
+ * Note: the env var is parsed on every call. Callers performing multiple
+ * checks within a single request should cache the result locally rather
+ * than re-invoking this function.
  */
 export function getAllowedDids(): string[] {
   const raw = env("AUTH_ALLOWED_DID") ?? "";
@@ -12,9 +16,4 @@ export function getAllowedDids(): string[] {
     .split(",")
     .map((d) => d.trim())
     .filter(Boolean);
-}
-
-export function isAllowedDid(did: string | undefined | null): boolean {
-  if (!did) return false;
-  return getAllowedDids().includes(did);
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { defineMiddleware } from "astro:middleware";
+import { getAllowedDids, isAllowedDid } from "@lib/auth/allowed";
 import { getSessionDid } from "@lib/auth/session";
 import { env } from "@lib/env";
 
@@ -39,8 +40,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
     console.warn("Ignoring DEV_BYPASS_AUTH: only allowed on localhost in dev mode.");
   }
 
-  const allowedDid = env("AUTH_ALLOWED_DID");
-  if (!allowedDid) {
+  const allowedDids = getAllowedDids();
+  if (allowedDids.length === 0) {
     console.error("Missing required AUTH_ALLOWED_DID configuration.");
     return new Response("Server misconfiguration: AUTH_ALLOWED_DID is not set.", {
       status: 500,
@@ -48,7 +49,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   }
 
   const did = getSessionDid(request);
-  if (!did || did !== allowedDid) {
+  if (!isAllowedDid(did)) {
     return context.redirect("/login");
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
 import { defineMiddleware } from "astro:middleware";
-import { getAllowedDids, isAllowedDid } from "@lib/auth/allowed";
+import { getAllowedDids } from "@lib/auth/allowed";
 import { getSessionDid } from "@lib/auth/session";
 import { env } from "@lib/env";
 
@@ -43,13 +43,14 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const allowedDids = getAllowedDids();
   if (allowedDids.length === 0) {
     console.error("Missing required AUTH_ALLOWED_DID configuration.");
-    return new Response("Server misconfiguration: AUTH_ALLOWED_DID is not set.", {
-      status: 500,
-    });
+    return new Response(
+      "Server misconfiguration: AUTH_ALLOWED_DID is not set or is empty/invalid.",
+      { status: 500 },
+    );
   }
 
   const did = getSessionDid(request);
-  if (!isAllowedDid(did)) {
+  if (!did || !allowedDids.includes(did)) {
     return context.redirect("/login");
   }
 

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -1,16 +1,18 @@
 ---
-import { getAllowedDids, isAllowedDid } from "@lib/auth/allowed";
+import { getAllowedDids } from "@lib/auth/allowed";
 import { getSessionDid } from "@lib/auth/session";
 
-if (getAllowedDids().length === 0) {
-  return new Response("Server misconfiguration: AUTH_ALLOWED_DID is not set.", {
-    status: 500,
-  });
+const allowedDids = getAllowedDids();
+if (allowedDids.length === 0) {
+  return new Response(
+    "Server misconfiguration: AUTH_ALLOWED_DID is not set or is empty/invalid.",
+    { status: 500 },
+  );
 }
 
 // Already logged in → redirect home
 const did = getSessionDid(Astro.request);
-if (isAllowedDid(did)) {
+if (did && allowedDids.includes(did)) {
   return Astro.redirect("/");
 }
 

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -1,9 +1,8 @@
 ---
+import { getAllowedDids, isAllowedDid } from "@lib/auth/allowed";
 import { getSessionDid } from "@lib/auth/session";
-import { env } from "@lib/env";
 
-const allowedDid = env("AUTH_ALLOWED_DID");
-if (!allowedDid) {
+if (getAllowedDids().length === 0) {
   return new Response("Server misconfiguration: AUTH_ALLOWED_DID is not set.", {
     status: 500,
   });
@@ -11,7 +10,7 @@ if (!allowedDid) {
 
 // Already logged in → redirect home
 const did = getSessionDid(Astro.request);
-if (did && did === allowedDid) {
+if (isAllowedDid(did)) {
   return Astro.redirect("/");
 }
 

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -77,9 +77,7 @@ const errorMessage = error
           class="border border-slate-800 bg-slate-900/80 p-8 backdrop-blur-sm"
         >
           <div class="mb-6">
-            <h2 class="text-lg tracking-tight text-white">
-              Sign in
-            </h2>
+            <h2 class="text-lg tracking-tight text-white">Sign in</h2>
             <p class="mt-1 text-sm text-slate-500">
               Use your Bluesky account to continue.
             </p>

--- a/src/pages/oauth/callback.astro
+++ b/src/pages/oauth/callback.astro
@@ -1,7 +1,7 @@
 ---
+import { getAllowedDids, isAllowedDid } from "@lib/auth/allowed";
 import { getOAuthClient } from "@lib/auth/client";
 import { setSessionCookie } from "@lib/auth/session";
-import { env } from "@lib/env";
 
 const params = Astro.url.searchParams;
 
@@ -15,12 +15,11 @@ try {
   const { session } = await client.callback(params);
   const { did } = session;
 
-  const allowedDid = env("AUTH_ALLOWED_DID");
-  if (!allowedDid) {
+  if (getAllowedDids().length === 0) {
     console.error("Missing required AUTH_ALLOWED_DID configuration.");
     return new Response("Server misconfiguration: AUTH_ALLOWED_DID is not set.", { status: 500 });
   }
-  if (did !== allowedDid) {
+  if (!isAllowedDid(did)) {
     return Astro.redirect("/login?error=unauthorized");
   }
 

--- a/src/pages/oauth/callback.astro
+++ b/src/pages/oauth/callback.astro
@@ -6,7 +6,11 @@ import { setSessionCookie } from "@lib/auth/session";
 const params = Astro.url.searchParams;
 
 if (params.get("error")) {
-  console.error("[auth] OAuth provider error:", params.get("error"), params.get("error_description"));
+  console.error(
+    "[auth] OAuth provider error:",
+    params.get("error"),
+    params.get("error_description"),
+  );
   return Astro.redirect("/login?error=oauth_error");
 }
 
@@ -17,7 +21,10 @@ try {
 
   if (getAllowedDids().length === 0) {
     console.error("Missing required AUTH_ALLOWED_DID configuration.");
-    return new Response("Server misconfiguration: AUTH_ALLOWED_DID is not set.", { status: 500 });
+    return new Response(
+      "Server misconfiguration: AUTH_ALLOWED_DID is not set.",
+      { status: 500 },
+    );
   }
   if (!isAllowedDid(did)) {
     return Astro.redirect("/login?error=unauthorized");

--- a/src/pages/oauth/callback.astro
+++ b/src/pages/oauth/callback.astro
@@ -1,5 +1,5 @@
 ---
-import { getAllowedDids, isAllowedDid } from "@lib/auth/allowed";
+import { getAllowedDids } from "@lib/auth/allowed";
 import { getOAuthClient } from "@lib/auth/client";
 import { setSessionCookie } from "@lib/auth/session";
 
@@ -19,14 +19,15 @@ try {
   const { session } = await client.callback(params);
   const { did } = session;
 
-  if (getAllowedDids().length === 0) {
+  const allowedDids = getAllowedDids();
+  if (allowedDids.length === 0) {
     console.error("Missing required AUTH_ALLOWED_DID configuration.");
     return new Response(
-      "Server misconfiguration: AUTH_ALLOWED_DID is not set.",
+      "Server misconfiguration: AUTH_ALLOWED_DID is not set or is empty/invalid.",
       { status: 500 },
     );
   }
-  if (!isAllowedDid(did)) {
+  if (!allowedDids.includes(did)) {
     return Astro.redirect("/login?error=unauthorized");
   }
 


### PR DESCRIPTION
This pull request refactors authentication logic to support multiple allowed DIDs (Decentralized Identifiers) instead of just one, improving flexibility and maintainability. The main change is the introduction of new utility functions for handling allowed DIDs, and updating all authentication checks to use these functions. Comprehensive unit tests are also added to ensure correctness.

**Authentication logic improvements:**

* Added `getAllowedDids` and `isAllowedDid` utility functions in `src/lib/auth/allowed.ts` to read and process the `AUTH_ALLOWED_DID` environment variable as a comma-separated list, supporting multiple DIDs and trimming whitespace.
* Updated authentication checks in `src/middleware.ts`, `src/pages/login.astro`, and `src/pages/oauth/callback.astro` to use `getAllowedDids` and `isAllowedDid` for validating user DIDs, replacing previous single-value logic. [[1]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0R2) [[2]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0L42-R52) [[3]](diffhunk://#diff-457bebb1ac6dcb7fdb5f55c63a2e3b9fa6d3f6a6361ce9b33c082ebe58c127bbR2-R13) [[4]](diffhunk://#diff-457bebb1ac6dcb7fdb5f55c63a2e3b9fa6d3f6a6361ce9b33c082ebe58c127bbL81-R80) [[5]](diffhunk://#diff-5c9e7560c872b438ea425711920f0910614dddb9edb14b14bcf4666e41bd421aR2-R13) [[6]](diffhunk://#diff-5c9e7560c872b438ea425711920f0910614dddb9edb14b14bcf4666e41bd421aL18-R29)

**Testing:**

* Added comprehensive unit tests for the new allowed DID logic in `src/lib/auth/allowed.test.ts`, covering edge cases and expected behaviors.