### PR TITLE
feat: add offline storage foundation

### DIFF
--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -1,4 +1,4 @@
-import { JoseKey } from "@atproto/jwk-jose";
+import { JoseKey, type Jwk } from "@atproto/jwk-jose";
 import { NodeOAuthClient } from "@atproto/oauth-client-node";
 import { env } from "@lib/env";
 import { ElasticKeyedStore } from "./store";
@@ -99,7 +99,7 @@ export async function getOAuthClient(): Promise<NodeOAuthClient> {
 	// `kid` (key ID) is required by the private_key_jwt auth method so the PDS
 	// can match the assertion to the correct key in our JWKS.
 	if (!parsedKey.kid) parsedKey.kid = "key-1";
-	const privateKey = await JoseKey.fromImportable(parsedKey);
+	const privateKey = await JoseKey.fromImportable(parsedKey as Jwk);
 	// Strip the private scalar `d` to derive the public JWK for the JWKS endpoint.
 	const { d: _d, ...publicJwk } = parsedKey;
 

--- a/src/lib/offline/cache-names.ts
+++ b/src/lib/offline/cache-names.ts
@@ -1,0 +1,17 @@
+/** Existing cache bucket containing downloaded comic archives. */
+export const LEGACY_COMIC_ARCHIVE_CACHE_NAME = "comic-reader-v1";
+export const COMIC_ARCHIVE_CACHE_NAME = "comic-reader-v2";
+
+/** Cache buckets reserved for the PWA shell, documents, and offline covers. */
+export const OFFLINE_ASSET_CACHE_NAME = "comics-offline-assets-v1";
+export const OFFLINE_DOCUMENT_CACHE_NAME = "comics-offline-pages-v1";
+export const OFFLINE_COVER_CACHE_NAME = "comics-offline-covers-v1";
+
+/** Every Cache Storage bucket owned by offline mode and cleared on logout. */
+export const KNOWN_OFFLINE_CACHE_NAMES = [
+	LEGACY_COMIC_ARCHIVE_CACHE_NAME,
+	COMIC_ARCHIVE_CACHE_NAME,
+	OFFLINE_ASSET_CACHE_NAME,
+	OFFLINE_DOCUMENT_CACHE_NAME,
+	OFFLINE_COVER_CACHE_NAME,
+] as const;

--- a/src/lib/offline/clear.ts
+++ b/src/lib/offline/clear.ts
@@ -1,0 +1,59 @@
+import { KNOWN_OFFLINE_CACHE_NAMES } from "./cache-names";
+import {
+	closeOfflineDatabase,
+	getOfflineDatabaseName,
+	isOfflineStorageSupported,
+} from "./database";
+
+export type ClearOfflineDataResult = {
+	databaseDeleted: boolean;
+	deletedCaches: string[];
+};
+
+export type ClearOfflineDataOptions = {
+	/** Test seam for isolating Cache Storage buckets on a shared origin. */
+	cacheNames?: readonly string[];
+};
+
+async function deleteOfflineDatabase(): Promise<boolean> {
+	if (!isOfflineStorageSupported()) return false;
+	await closeOfflineDatabase();
+
+	return new Promise((resolve, reject) => {
+		const request = indexedDB.deleteDatabase(getOfflineDatabaseName());
+		request.onsuccess = () => resolve(true);
+		request.onerror = () => reject(request.error);
+	});
+}
+
+async function deleteOfflineCaches(
+	cacheNames: readonly string[],
+): Promise<string[]> {
+	if (typeof caches === "undefined") return [];
+
+	const results = await Promise.all(
+		cacheNames.map(async (cacheName) => ({
+			cacheName,
+			deleted: await caches.delete(cacheName),
+		})),
+	);
+
+	return results
+		.filter(({ deleted }) => deleted)
+		.map(({ cacheName }) => cacheName);
+}
+
+/**
+ * Permanently removes every IndexedDB and Cache Storage bucket owned by
+ * offline mode. Authentication code can call this without importing UI code.
+ */
+export async function clearOfflineData(
+	options: ClearOfflineDataOptions = {},
+): Promise<ClearOfflineDataResult> {
+	const [databaseDeleted, deletedCaches] = await Promise.all([
+		deleteOfflineDatabase(),
+		deleteOfflineCaches(options.cacheNames ?? KNOWN_OFFLINE_CACHE_NAMES),
+	]);
+
+	return { databaseDeleted, deletedCaches };
+}

--- a/src/lib/offline/database.browser.test.ts
+++ b/src/lib/offline/database.browser.test.ts
@@ -1,0 +1,320 @@
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "vitest";
+import { KNOWN_OFFLINE_CACHE_NAMES } from "./cache-names";
+import { clearOfflineData } from "./clear";
+import {
+	closeOfflineDatabase,
+	getOfflineDatabaseName,
+	OFFLINE_DATABASE_NAME,
+	OFFLINE_DATABASE_VERSION,
+	OFFLINE_STORE_NAMES,
+	offlineComics,
+	offlineOutbox,
+	offlineProgress,
+	offlineState,
+	openOfflineDatabase,
+	queueProgressUpdate,
+	setOfflineDatabaseNameForTesting,
+} from "./database";
+import type {
+	OfflineComicRecord,
+	OfflineOutboxRecord,
+	OfflineProgressRecord,
+} from "./types";
+
+const comic: OfflineComicRecord = {
+	issueId: "issue-1",
+	seriesId: "series-1",
+	seriesName: "The Example",
+	seriesYear: "2026",
+	issueNumber: 1,
+	archiveCacheKey: "/api/comic/issue-1/download",
+	sizeBytes: 42,
+	cachedAt: "2026-08-16T10:00:00.000Z",
+	updatedAt: "2026-08-16T10:00:00.000Z",
+};
+
+const progress: OfflineProgressRecord = {
+	issueId: comic.issueId,
+	currentPage: 8,
+	updatedAt: "2026-08-16T11:00:00.000Z",
+	syncStatus: "pending",
+};
+
+const progressMutation: OfflineOutboxRecord = {
+	id: "mutation-1",
+	dedupeKey: `progress:${comic.issueId}`,
+	kind: "progress",
+	payload: {
+		issueId: comic.issueId,
+		currentPage: progress.currentPage,
+		totalPages: 24,
+		updatedAt: progress.updatedAt,
+		mutationId: "mutation-1",
+	},
+	createdAt: "2026-08-16T11:00:00.000Z",
+	updatedAt: "2026-08-16T11:00:00.000Z",
+	attempts: 0,
+	status: "pending",
+};
+
+const testRunId = crypto.randomUUID();
+const TEST_DATABASE_NAME = `${OFFLINE_DATABASE_NAME}-database-browser-${testRunId}`;
+const TEST_CACHE_NAMES = KNOWN_OFFLINE_CACHE_NAMES.map(
+	(name) => `${name}-database-browser-${testRunId}`,
+);
+const UNRELATED_TEST_CACHE_NAME = `unrelated-cache-${testRunId}`;
+
+async function deleteTestDatabase(): Promise<void> {
+	await closeOfflineDatabase();
+	await new Promise<void>((resolve, reject) => {
+		const request = indexedDB.deleteDatabase(getOfflineDatabaseName());
+		request.onsuccess = () => resolve();
+		request.onerror = () => reject(request.error);
+		request.onblocked = () =>
+			reject(new Error("Test database deletion blocked"));
+	});
+}
+
+async function cleanOfflineTestData(): Promise<void> {
+	await deleteTestDatabase();
+}
+
+beforeAll(() => setOfflineDatabaseNameForTesting(TEST_DATABASE_NAME));
+beforeEach(cleanOfflineTestData);
+afterEach(cleanOfflineTestData);
+afterAll(async () => {
+	await Promise.all(TEST_CACHE_NAMES.map((name) => caches.delete(name)));
+	await caches.delete(UNRELATED_TEST_CACHE_NAME);
+	await setOfflineDatabaseNameForTesting(OFFLINE_DATABASE_NAME);
+});
+
+describe("offline database schema", () => {
+	test("creates every current store and index", async () => {
+		const database = await openOfflineDatabase();
+
+		expect(database.version).toBe(OFFLINE_DATABASE_VERSION);
+		expect(Array.from(database.objectStoreNames)).toEqual([
+			OFFLINE_STORE_NAMES.comics,
+			OFFLINE_STORE_NAMES.state,
+			OFFLINE_STORE_NAMES.outbox,
+			OFFLINE_STORE_NAMES.progress,
+		]);
+
+		const transaction = database.transaction(
+			[OFFLINE_STORE_NAMES.comics, OFFLINE_STORE_NAMES.outbox],
+			"readonly",
+		);
+		const transactionDone = new Promise<void>((resolve, reject) => {
+			transaction.oncomplete = () => resolve();
+			transaction.onerror = () => reject(transaction.error);
+			transaction.onabort = () => reject(transaction.error);
+		});
+		expect(
+			Array.from(
+				transaction.objectStore(OFFLINE_STORE_NAMES.comics).indexNames,
+			),
+		).toEqual(["cachedAt", "seriesId"]);
+		expect(
+			Array.from(
+				transaction.objectStore(OFFLINE_STORE_NAMES.outbox).indexNames,
+			),
+		).toEqual(["createdAt", "dedupeKey", "kind"]);
+		await transactionDone;
+	});
+
+	test("upgrades a version 1 database without losing records", async () => {
+		const legacyRecord = { ...comic, seriesName: "Preserved from v1" };
+		await new Promise<void>((resolve, reject) => {
+			const request = indexedDB.open(getOfflineDatabaseName(), 1);
+			request.onupgradeneeded = () => {
+				const comicsStore = request.result.createObjectStore(
+					OFFLINE_STORE_NAMES.comics,
+					{
+						keyPath: "issueId",
+					},
+				);
+				comicsStore.createIndex("seriesId", "seriesId", { unique: false });
+				comicsStore.createIndex("cachedAt", "cachedAt", { unique: false });
+				const progressStore = request.result.createObjectStore(
+					OFFLINE_STORE_NAMES.progress,
+					{
+						keyPath: "issueId",
+					},
+				);
+				progressStore.createIndex("updatedAt", "updatedAt", {
+					unique: false,
+				});
+			};
+			request.onerror = () => reject(request.error);
+			request.onsuccess = () => {
+				const database = request.result;
+				const transaction = database.transaction(
+					OFFLINE_STORE_NAMES.comics,
+					"readwrite",
+				);
+				transaction.objectStore(OFFLINE_STORE_NAMES.comics).put(legacyRecord);
+				transaction.oncomplete = () => {
+					database.close();
+					resolve();
+				};
+				transaction.onerror = () => reject(transaction.error);
+			};
+		});
+
+		const database = await openOfflineDatabase();
+		expect(database.version).toBe(OFFLINE_DATABASE_VERSION);
+		expect(database.objectStoreNames.contains(OFFLINE_STORE_NAMES.outbox)).toBe(
+			true,
+		);
+		expect(database.objectStoreNames.contains(OFFLINE_STORE_NAMES.state)).toBe(
+			true,
+		);
+		expect(await offlineComics.get(comic.issueId)).toEqual(legacyRecord);
+	});
+});
+
+describe("typed offline repositories", () => {
+	test("creates, reads, queries, updates, and deletes comic metadata", async () => {
+		const anotherComic: OfflineComicRecord = {
+			...comic,
+			issueId: "issue-2",
+			issueNumber: 2,
+			archiveCacheKey: "/api/comic/issue-2/download",
+		};
+
+		await offlineComics.put(comic);
+		await offlineComics.put(anotherComic);
+		expect(await offlineComics.count()).toBe(2);
+		expect(await offlineComics.get(comic.issueId)).toEqual(comic);
+		expect(await offlineComics.getBySeries(comic.seriesId)).toEqual([
+			comic,
+			anotherComic,
+		]);
+
+		await offlineComics.put({ ...comic, issueName: "Updated" });
+		expect((await offlineComics.get(comic.issueId))?.issueName).toBe("Updated");
+		await offlineComics.delete(comic.issueId);
+		expect(await offlineComics.get(comic.issueId)).toBeUndefined();
+		await offlineComics.clear();
+		expect(await offlineComics.getAll()).toEqual([]);
+	});
+
+	test("stores progress and arbitrary typed offline state", async () => {
+		await offlineProgress.put(progress);
+		expect(await offlineProgress.get(progress.issueId)).toEqual(progress);
+
+		await offlineState.set("readiness", { ready: true }, progress.updatedAt);
+		expect(await offlineState.get<{ ready: boolean }>("readiness")).toEqual({
+			ready: true,
+		});
+		expect(await offlineState.getRecord("readiness")).toEqual({
+			key: "readiness",
+			value: { ready: true },
+			updatedAt: progress.updatedAt,
+		});
+
+		await offlineProgress.delete(progress.issueId);
+		await offlineState.delete("readiness");
+		expect(await offlineProgress.count()).toBe(0);
+		expect(await offlineState.count()).toBe(0);
+	});
+
+	test("orders outbox records and replaces matching dedupe keys", async () => {
+		const libraryMutation: OfflineOutboxRecord = {
+			id: "mutation-2",
+			dedupeKey: "library:series-1",
+			kind: "add-to-library",
+			payload: { seriesId: "series-1" },
+			createdAt: "2026-08-16T10:00:00.000Z",
+			updatedAt: "2026-08-16T10:00:00.000Z",
+			attempts: 0,
+			status: "pending",
+		};
+		await offlineOutbox.put(progressMutation);
+		await offlineOutbox.put(libraryMutation);
+
+		expect((await offlineOutbox.getAll()).map(({ id }) => id)).toEqual([
+			"mutation-2",
+			"mutation-1",
+		]);
+		expect(await offlineOutbox.getByKind("progress")).toEqual([
+			progressMutation,
+		]);
+
+		const replacement = {
+			...progressMutation,
+			id: "mutation-3",
+			payload: { ...progressMutation.payload, currentPage: 12 },
+		};
+		await offlineOutbox.put(replacement);
+		expect(await offlineOutbox.get(progressMutation.id)).toBeUndefined();
+		expect(
+			await offlineOutbox.getByDedupeKey(progressMutation.dedupeKey),
+		).toEqual(replacement);
+		expect(await offlineOutbox.count()).toBe(2);
+	});
+
+	test("writes local progress and its outbox entry atomically", async () => {
+		await queueProgressUpdate(progress, progressMutation);
+		expect(await offlineProgress.get(progress.issueId)).toEqual(progress);
+		expect(await offlineOutbox.get(progressMutation.id)).toEqual(
+			progressMutation,
+		);
+
+		await expect(
+			queueProgressUpdate(progress, {
+				...progressMutation,
+				id: "wrong-target",
+				payload: { ...progressMutation.payload, issueId: "issue-2" },
+			}),
+		).rejects.toThrow("must target the same issue");
+		expect(await offlineOutbox.get("wrong-target")).toBeUndefined();
+	});
+});
+
+describe("clearOfflineData", () => {
+	test("deletes the offline database and all owned cache buckets", async () => {
+		await offlineComics.put(comic);
+		for (const cacheName of TEST_CACHE_NAMES) {
+			const cache = await caches.open(cacheName);
+			await cache.put("/stored", new Response(cacheName));
+		}
+		const unrelated = await caches.open(UNRELATED_TEST_CACHE_NAME);
+		await unrelated.put("/keep", new Response("keep"));
+
+		const result = await clearOfflineData({ cacheNames: TEST_CACHE_NAMES });
+
+		expect(result.databaseDeleted).toBe(true);
+		expect(result.deletedCaches.sort()).toEqual([...TEST_CACHE_NAMES].sort());
+		const cacheNames = await caches.keys();
+		expect(cacheNames).not.toContain(TEST_CACHE_NAMES[0]);
+		expect(cacheNames).toContain(UNRELATED_TEST_CACHE_NAME);
+
+		// A subsequent open creates a fresh, empty database.
+		await openOfflineDatabase();
+		expect(await offlineComics.getAll()).toEqual([]);
+	});
+
+	test("is idempotent when no offline data exists", async () => {
+		await expect(
+			clearOfflineData({ cacheNames: TEST_CACHE_NAMES }),
+		).resolves.toEqual({
+			databaseDeleted: true,
+			deletedCaches: [],
+		});
+		await expect(
+			clearOfflineData({ cacheNames: TEST_CACHE_NAMES }),
+		).resolves.toEqual({
+			databaseDeleted: true,
+			deletedCaches: [],
+		});
+	});
+});

--- a/src/lib/offline/database.ts
+++ b/src/lib/offline/database.ts
@@ -1,0 +1,365 @@
+import type {
+	OfflineComicRecord,
+	OfflineOutboxRecord,
+	OfflineProgressRecord,
+	OfflineStateRecord,
+} from "./types";
+
+export const OFFLINE_DATABASE_NAME = "comics-offline";
+export const OFFLINE_DATABASE_VERSION = 2;
+
+export const OFFLINE_STORE_NAMES = {
+	comics: "comics",
+	progress: "progress",
+	outbox: "outbox",
+	state: "offline-state",
+} as const;
+
+export type OfflineStoreName =
+	(typeof OFFLINE_STORE_NAMES)[keyof typeof OFFLINE_STORE_NAMES];
+
+let databasePromise: Promise<IDBDatabase> | undefined;
+let databaseName = OFFLINE_DATABASE_NAME;
+
+/** The database name currently used by this module instance. */
+export function getOfflineDatabaseName(): string {
+	return databaseName;
+}
+
+/**
+ * Points this module instance at an isolated database for browser tests.
+ *
+ * Production code must use the default name. Tests that run concurrently on
+ * the same origin need separate names because IndexedDB connections are shared
+ * across browser test files even when their JavaScript realms are isolated.
+ */
+export async function setOfflineDatabaseNameForTesting(
+	name: string,
+): Promise<void> {
+	if (!name.trim()) throw new Error("Offline database name cannot be empty");
+	await closeOfflineDatabase();
+	databaseName = name;
+}
+
+/** Whether this runtime exposes the browser IndexedDB API. */
+export function isOfflineStorageSupported(): boolean {
+	return typeof indexedDB !== "undefined";
+}
+
+function createV1Stores(database: IDBDatabase): void {
+	if (!database.objectStoreNames.contains(OFFLINE_STORE_NAMES.comics)) {
+		const comics = database.createObjectStore(OFFLINE_STORE_NAMES.comics, {
+			keyPath: "issueId",
+		});
+		comics.createIndex("seriesId", "seriesId", { unique: false });
+		comics.createIndex("cachedAt", "cachedAt", { unique: false });
+	}
+
+	if (!database.objectStoreNames.contains(OFFLINE_STORE_NAMES.progress)) {
+		const progress = database.createObjectStore(OFFLINE_STORE_NAMES.progress, {
+			keyPath: "issueId",
+		});
+		progress.createIndex("updatedAt", "updatedAt", { unique: false });
+	}
+}
+
+function createV2Stores(database: IDBDatabase): void {
+	if (!database.objectStoreNames.contains(OFFLINE_STORE_NAMES.outbox)) {
+		const outbox = database.createObjectStore(OFFLINE_STORE_NAMES.outbox, {
+			keyPath: "id",
+		});
+		outbox.createIndex("kind", "kind", { unique: false });
+		outbox.createIndex("createdAt", "createdAt", { unique: false });
+		outbox.createIndex("dedupeKey", "dedupeKey", { unique: true });
+	}
+
+	if (!database.objectStoreNames.contains(OFFLINE_STORE_NAMES.state)) {
+		database.createObjectStore(OFFLINE_STORE_NAMES.state, { keyPath: "key" });
+	}
+}
+
+function migrateDatabase(database: IDBDatabase, oldVersion: number): void {
+	if (oldVersion < 1) createV1Stores(database);
+	if (oldVersion < 2) createV2Stores(database);
+}
+
+/**
+ * Opens the offline database and applies every schema migration up to the
+ * current version. Connections close themselves when another tab upgrades it.
+ */
+export function openOfflineDatabase(): Promise<IDBDatabase> {
+	if (!isOfflineStorageSupported()) {
+		return Promise.reject(new Error("IndexedDB is not available"));
+	}
+	if (databasePromise) return databasePromise;
+
+	const openingDatabase = new Promise<IDBDatabase>((resolve, reject) => {
+		const request = indexedDB.open(databaseName, OFFLINE_DATABASE_VERSION);
+
+		request.onupgradeneeded = (event) => {
+			migrateDatabase(request.result, event.oldVersion);
+		};
+		request.onerror = () => reject(request.error);
+		request.onsuccess = () => {
+			const database = request.result;
+			database.onversionchange = () => {
+				database.close();
+				databasePromise = undefined;
+			};
+			resolve(database);
+		};
+	}).catch((error) => {
+		databasePromise = undefined;
+		throw error;
+	});
+	databasePromise = openingDatabase;
+
+	return openingDatabase;
+}
+
+/** Close this module's shared connection, primarily before deletion/upgrades. */
+export async function closeOfflineDatabase(): Promise<void> {
+	const pendingDatabase = databasePromise;
+	databasePromise = undefined;
+	if (!pendingDatabase) return;
+
+	try {
+		(await pendingDatabase).close();
+	} catch {
+		// A failed open has no live connection to close.
+	}
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+	return new Promise((resolve, reject) => {
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () => reject(request.error);
+	});
+}
+
+function transactionComplete(transaction: IDBTransaction): Promise<void> {
+	return new Promise((resolve, reject) => {
+		transaction.oncomplete = () => resolve();
+		transaction.onerror = () => reject(transaction.error);
+		transaction.onabort = () =>
+			reject(transaction.error ?? new Error("IndexedDB transaction aborted"));
+	});
+}
+
+async function readRecord<T>(
+	storeName: OfflineStoreName,
+	key: IDBValidKey,
+): Promise<T | undefined> {
+	const database = await openOfflineDatabase();
+	const transaction = database.transaction(storeName, "readonly");
+	const [result] = await Promise.all([
+		requestResult<T | undefined>(transaction.objectStore(storeName).get(key)),
+		transactionComplete(transaction),
+	]);
+	return result;
+}
+
+async function readAllRecords<T>(storeName: OfflineStoreName): Promise<T[]> {
+	const database = await openOfflineDatabase();
+	const transaction = database.transaction(storeName, "readonly");
+	const [result] = await Promise.all([
+		requestResult<T[]>(transaction.objectStore(storeName).getAll()),
+		transactionComplete(transaction),
+	]);
+	return result;
+}
+
+async function putRecord<T>(
+	storeName: OfflineStoreName,
+	record: T,
+): Promise<void> {
+	const database = await openOfflineDatabase();
+	const transaction = database.transaction(storeName, "readwrite");
+	const completed = transactionComplete(transaction);
+	transaction.objectStore(storeName).put(record);
+	await completed;
+}
+
+async function deleteRecord(
+	storeName: OfflineStoreName,
+	key: IDBValidKey,
+): Promise<void> {
+	const database = await openOfflineDatabase();
+	const transaction = database.transaction(storeName, "readwrite");
+	const completed = transactionComplete(transaction);
+	transaction.objectStore(storeName).delete(key);
+	await completed;
+}
+
+async function clearStore(storeName: OfflineStoreName): Promise<void> {
+	const database = await openOfflineDatabase();
+	const transaction = database.transaction(storeName, "readwrite");
+	const completed = transactionComplete(transaction);
+	transaction.objectStore(storeName).clear();
+	await completed;
+}
+
+async function countRecords(storeName: OfflineStoreName): Promise<number> {
+	const database = await openOfflineDatabase();
+	const transaction = database.transaction(storeName, "readonly");
+	const [result] = await Promise.all([
+		requestResult(transaction.objectStore(storeName).count()),
+		transactionComplete(transaction),
+	]);
+	return result;
+}
+
+async function readAllFromIndex<T>(
+	storeName: OfflineStoreName,
+	indexName: string,
+	query: IDBValidKey | IDBKeyRange,
+): Promise<T[]> {
+	const database = await openOfflineDatabase();
+	const transaction = database.transaction(storeName, "readonly");
+	const [result] = await Promise.all([
+		requestResult<T[]>(
+			transaction.objectStore(storeName).index(indexName).getAll(query),
+		),
+		transactionComplete(transaction),
+	]);
+	return result;
+}
+
+async function putOutboxRecord(record: OfflineOutboxRecord): Promise<void> {
+	const database = await openOfflineDatabase();
+	const transaction = database.transaction(
+		OFFLINE_STORE_NAMES.outbox,
+		"readwrite",
+	);
+	const completed = transactionComplete(transaction);
+	const store = transaction.objectStore(OFFLINE_STORE_NAMES.outbox);
+	const existing = await requestResult<OfflineOutboxRecord | undefined>(
+		store.index("dedupeKey").get(record.dedupeKey),
+	);
+	if (existing && existing.id !== record.id) store.delete(existing.id);
+	store.put(record);
+	await completed;
+}
+
+export const offlineComics = {
+	get: (issueId: string) =>
+		readRecord<OfflineComicRecord>(OFFLINE_STORE_NAMES.comics, issueId),
+	getAll: () => readAllRecords<OfflineComicRecord>(OFFLINE_STORE_NAMES.comics),
+	getBySeries: (seriesId: string) =>
+		readAllFromIndex<OfflineComicRecord>(
+			OFFLINE_STORE_NAMES.comics,
+			"seriesId",
+			seriesId,
+		),
+	put: (record: OfflineComicRecord) =>
+		putRecord(OFFLINE_STORE_NAMES.comics, record),
+	delete: (issueId: string) =>
+		deleteRecord(OFFLINE_STORE_NAMES.comics, issueId),
+	clear: () => clearStore(OFFLINE_STORE_NAMES.comics),
+	count: () => countRecords(OFFLINE_STORE_NAMES.comics),
+};
+
+export const offlineProgress = {
+	get: (issueId: string) =>
+		readRecord<OfflineProgressRecord>(OFFLINE_STORE_NAMES.progress, issueId),
+	getAll: () =>
+		readAllRecords<OfflineProgressRecord>(OFFLINE_STORE_NAMES.progress),
+	put: (record: OfflineProgressRecord) =>
+		putRecord(OFFLINE_STORE_NAMES.progress, record),
+	delete: (issueId: string) =>
+		deleteRecord(OFFLINE_STORE_NAMES.progress, issueId),
+	clear: () => clearStore(OFFLINE_STORE_NAMES.progress),
+	count: () => countRecords(OFFLINE_STORE_NAMES.progress),
+};
+
+export const offlineOutbox = {
+	get: (id: string) =>
+		readRecord<OfflineOutboxRecord>(OFFLINE_STORE_NAMES.outbox, id),
+	getAll: async () => {
+		const records = await readAllRecords<OfflineOutboxRecord>(
+			OFFLINE_STORE_NAMES.outbox,
+		);
+		return records.sort((left, right) =>
+			left.createdAt.localeCompare(right.createdAt),
+		);
+	},
+	getByKind: (kind: OfflineOutboxRecord["kind"]) =>
+		readAllFromIndex<OfflineOutboxRecord>(
+			OFFLINE_STORE_NAMES.outbox,
+			"kind",
+			kind,
+		),
+	getByDedupeKey: async (dedupeKey: string) => {
+		const database = await openOfflineDatabase();
+		const transaction = database.transaction(
+			OFFLINE_STORE_NAMES.outbox,
+			"readonly",
+		);
+		const [result] = await Promise.all([
+			requestResult<OfflineOutboxRecord | undefined>(
+				transaction
+					.objectStore(OFFLINE_STORE_NAMES.outbox)
+					.index("dedupeKey")
+					.get(dedupeKey),
+			),
+			transactionComplete(transaction),
+		]);
+		return result;
+	},
+	/** Add a mutation, replacing an older record with the same dedupe key. */
+	put: putOutboxRecord,
+	delete: (id: string) => deleteRecord(OFFLINE_STORE_NAMES.outbox, id),
+	clear: () => clearStore(OFFLINE_STORE_NAMES.outbox),
+	count: () => countRecords(OFFLINE_STORE_NAMES.outbox),
+};
+
+export const offlineState = {
+	get: async <T = unknown>(key: string): Promise<T | undefined> => {
+		const record = await readRecord<OfflineStateRecord<T>>(
+			OFFLINE_STORE_NAMES.state,
+			key,
+		);
+		return record?.value;
+	},
+	getRecord: <T = unknown>(key: string) =>
+		readRecord<OfflineStateRecord<T>>(OFFLINE_STORE_NAMES.state, key),
+	set: <T>(key: string, value: T, updatedAt = new Date().toISOString()) =>
+		putRecord<OfflineStateRecord<T>>(OFFLINE_STORE_NAMES.state, {
+			key,
+			value,
+			updatedAt,
+		}),
+	delete: (key: string) => deleteRecord(OFFLINE_STORE_NAMES.state, key),
+	clear: () => clearStore(OFFLINE_STORE_NAMES.state),
+	count: () => countRecords(OFFLINE_STORE_NAMES.state),
+};
+
+/**
+ * Atomically writes progress and its matching outbox mutation.
+ *
+ * Keeping these records in one transaction prevents a crash from leaving
+ * locally visible progress that can never be synchronized.
+ */
+export async function queueProgressUpdate(
+	progress: OfflineProgressRecord,
+	mutation: Extract<OfflineOutboxRecord, { kind: "progress" }>,
+): Promise<void> {
+	if (progress.issueId !== mutation.payload.issueId) {
+		throw new Error("Progress and outbox mutation must target the same issue");
+	}
+
+	const database = await openOfflineDatabase();
+	const transaction = database.transaction(
+		[OFFLINE_STORE_NAMES.progress, OFFLINE_STORE_NAMES.outbox],
+		"readwrite",
+	);
+	const completed = transactionComplete(transaction);
+	const outbox = transaction.objectStore(OFFLINE_STORE_NAMES.outbox);
+	const existing = await requestResult<OfflineOutboxRecord | undefined>(
+		outbox.index("dedupeKey").get(mutation.dedupeKey),
+	);
+	if (existing && existing.id !== mutation.id) outbox.delete(existing.id);
+	transaction.objectStore(OFFLINE_STORE_NAMES.progress).put(progress);
+	outbox.put(mutation);
+	await completed;
+}

--- a/src/lib/offline/index.ts
+++ b/src/lib/offline/index.ts
@@ -1,0 +1,4 @@
+export * from "./cache-names";
+export * from "./clear";
+export * from "./database";
+export * from "./types";

--- a/src/lib/offline/types.ts
+++ b/src/lib/offline/types.ts
@@ -1,0 +1,88 @@
+/** A reference used to preserve the server's issue ordering while offline. */
+export type OfflineIssueReference = {
+	issueId: string;
+	issueNumber: number | string;
+	issueName?: string;
+};
+
+/**
+ * Searchable metadata for a comic whose archive is available offline.
+ *
+ * Binary archives and covers live in Cache Storage. This record deliberately
+ * contains only structured data and cache keys so it remains cheap to query.
+ */
+export type OfflineComicRecord = {
+	issueId: string;
+	seriesId: string;
+	seriesName: string;
+	seriesYear?: string;
+	seriesPublisher?: string;
+	issueNumber: number | string;
+	issueName?: string;
+	issueDate?: string;
+	pageCount?: number;
+	coverUrl?: string;
+	coverCacheKey?: string;
+	coverThumbHash?: string;
+	archiveCacheKey: string;
+	sizeBytes: number;
+	cachedAt: string;
+	updatedAt: string;
+	previousIssue?: OfflineIssueReference | null;
+	nextIssue?: OfflineIssueReference | null;
+};
+
+/** Reading progress stored locally before, during, and after synchronization. */
+export type OfflineProgressRecord = {
+	issueId: string;
+	currentPage: number;
+	totalPages?: number;
+	updatedAt: string;
+	syncStatus: "synced" | "pending" | "failed";
+	lastError?: string;
+};
+
+type OutboxRecordBase = {
+	/** Client-generated id used to make replay idempotent. */
+	id: string;
+	/** Stable key used to replace an older pending mutation for the same target. */
+	dedupeKey: string;
+	createdAt: string;
+	updatedAt: string;
+	attempts: number;
+	status: "pending" | "failed";
+	nextAttemptAt?: string;
+	lastError?: string;
+};
+
+/** A reading-progress write waiting to be replayed online. */
+export type ProgressOutboxRecord = OutboxRecordBase & {
+	kind: "progress";
+	payload: {
+		issueId: string;
+		currentPage: number;
+		totalPages: number;
+		updatedAt: string;
+		mutationId: string;
+	};
+};
+
+/** An add-to-library write waiting to be replayed online. */
+export type AddToLibraryOutboxRecord = OutboxRecordBase & {
+	kind: "add-to-library";
+	payload: {
+		seriesId: string;
+	};
+};
+
+/** A server mutation waiting for the next online foreground session. */
+export type OfflineOutboxRecord =
+	| ProgressOutboxRecord
+	| AddToLibraryOutboxRecord;
+
+/** A small piece of versioned application state used by offline orchestration. */
+export type OfflineStateRecord<T = unknown> = {
+	key: string;
+	value: T;
+	updatedAt: string;
+};


### PR DESCRIPTION
## Summary

- add a versioned `comics-offline` IndexedDB schema for downloaded metadata, progress, queued mutations, and coordination state
- expose typed repositories, indexes, and atomic progress/outbox writes
- centralize owned Cache Storage names and the complete offline-data purge boundary
- preserve v1 records during the v2 migration and cover the real browser APIs with migration, CRUD, atomicity, and purge tests
- include the strict JWK compatibility fix required for the current `main` branch to pass TypeScript

## Why

This is the storage foundation for the offline-mode stack. It deliberately adds no user-facing PWA behavior yet; later stacked PRs build bundles, navigation, reading, and synchronization on these stable repositories.

## Stack

- **1 of 9**
- Base: `main`
- Next: `codex/offline-outbox`

## Validation

- `npm test` — 209 tests passed
- `npm run type:check:tsc`
