### PR TITLE
feat: add replayable offline outbox

### DIFF
--- a/src/lib/offline/index.ts
+++ b/src/lib/offline/index.ts
@@ -1,4 +1,5 @@
 export * from "./cache-names";
 export * from "./clear";
 export * from "./database";
+export * from "./outbox";
 export * from "./types";

--- a/src/lib/offline/outbox.test.ts
+++ b/src/lib/offline/outbox.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+	createOutboxReplayEngine,
+	getOutboxCounts,
+	type OutboxReplayEvent,
+	type OutboxRepository,
+} from "./outbox";
+import type {
+	AddToLibraryOutboxRecord,
+	OfflineOutboxRecord,
+	ProgressOutboxRecord,
+} from "./types";
+
+const progressRecord: ProgressOutboxRecord = {
+	id: "progress-1",
+	dedupeKey: "progress:issue-1",
+	kind: "progress",
+	payload: {
+		issueId: "issue-1",
+		currentPage: 10,
+		totalPages: 24,
+		updatedAt: "2026-08-16T10:01:00.000Z",
+		mutationId: "progress-1",
+	},
+	createdAt: "2026-08-16T10:01:00.000Z",
+	updatedAt: "2026-08-16T10:01:00.000Z",
+	attempts: 0,
+	status: "pending",
+};
+
+const libraryRecord: AddToLibraryOutboxRecord = {
+	id: "library-1",
+	dedupeKey: "library:series-1",
+	kind: "add-to-library",
+	payload: { seriesId: "series-1" },
+	createdAt: "2026-08-16T10:00:00.000Z",
+	updatedAt: "2026-08-16T10:00:00.000Z",
+	attempts: 0,
+	status: "pending",
+};
+
+class MemoryOutboxRepository implements OutboxRepository {
+	readonly records = new Map<string, OfflineOutboxRecord>();
+
+	constructor(records: OfflineOutboxRecord[] = []) {
+		for (const record of records) this.records.set(record.id, record);
+	}
+
+	async getAll(): Promise<OfflineOutboxRecord[]> {
+		return [...this.records.values()];
+	}
+
+	async getByDedupeKey(
+		dedupeKey: string,
+	): Promise<OfflineOutboxRecord | undefined> {
+		return [...this.records.values()].find(
+			(record) => record.dedupeKey === dedupeKey,
+		);
+	}
+
+	async put(record: OfflineOutboxRecord): Promise<void> {
+		const existing = await this.getByDedupeKey(record.dedupeKey);
+		if (existing && existing.id !== record.id) this.records.delete(existing.id);
+		this.records.set(record.id, record);
+	}
+
+	async delete(id: string): Promise<void> {
+		this.records.delete(id);
+	}
+}
+
+function deferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+} {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function createHandlers() {
+	return {
+		progress: vi.fn(
+			async (): Promise<{ status: number; statusText?: string }> => ({
+				status: 204,
+			}),
+		),
+		"add-to-library": vi.fn(
+			async (): Promise<{ status: number; statusText?: string }> => ({
+				status: 200,
+			}),
+		),
+	};
+}
+
+describe("OutboxReplayEngine", () => {
+	test("replays pending records in creation order and deletes 2xx successes", async () => {
+		const repository = new MemoryOutboxRepository([
+			progressRecord,
+			libraryRecord,
+			{
+				...progressRecord,
+				id: "failed",
+				dedupeKey: "progress:failed",
+				status: "failed",
+			},
+		]);
+		const order: string[] = [];
+		const events: OutboxReplayEvent[] = [];
+		const engine = createOutboxReplayEngine({
+			repository,
+			handlers: {
+				progress: async (record) => {
+					order.push(record.id);
+					return { status: 204 };
+				},
+				"add-to-library": async (record) => {
+					order.push(record.id);
+					return { status: 201 };
+				},
+			},
+			onAuthInvalid: vi.fn(),
+		});
+		engine.subscribe((event) => events.push(event));
+
+		await expect(engine.replay()).resolves.toEqual({
+			attempted: 2,
+			succeeded: 2,
+			retryScheduled: 0,
+			failed: 0,
+			superseded: 0,
+			skippedNotDue: 0,
+			authInvalid: false,
+		});
+
+		expect(order).toEqual(["library-1", "progress-1"]);
+		expect([...repository.records.keys()]).toEqual(["failed"]);
+		expect(engine.state).toEqual({
+			isReplaying: false,
+			counts: { pending: 0, failed: 1, total: 1 },
+		});
+		expect(
+			events
+				.filter((event) => event.type === "record")
+				.map((event) => [event.record.id, event.outcome]),
+		).toEqual([
+			["library-1", "succeeded"],
+			["progress-1", "succeeded"],
+		]);
+		expect(events.at(-1)).toMatchObject({
+			type: "state",
+			state: { isReplaying: false },
+		});
+	});
+
+	test("retains network and 5xx failures with retry metadata", async () => {
+		const repository = new MemoryOutboxRepository([
+			libraryRecord,
+			progressRecord,
+		]);
+		const engine = createOutboxReplayEngine({
+			repository,
+			handlers: {
+				progress: async () => ({ status: 503, statusText: "Unavailable" }),
+				"add-to-library": async () => {
+					throw new TypeError("Failed to fetch");
+				},
+			},
+			onAuthInvalid: vi.fn(),
+			now: () => new Date("2026-08-16T12:00:00.000Z"),
+			retryDelayMs: (attempts) => attempts * 5_000,
+		});
+
+		const summary = await engine.replay();
+
+		expect(summary.retryScheduled).toBe(2);
+		expect(repository.records.get(libraryRecord.id)).toMatchObject({
+			attempts: 1,
+			status: "pending",
+			lastError: "Failed to fetch",
+			nextAttemptAt: "2026-08-16T12:00:05.000Z",
+		});
+		expect(repository.records.get(progressRecord.id)).toMatchObject({
+			attempts: 1,
+			status: "pending",
+			lastError: "HTTP 503: Unavailable",
+			nextAttemptAt: "2026-08-16T12:00:05.000Z",
+		});
+
+		const second = await engine.replay();
+		expect(second).toMatchObject({ attempted: 0, skippedNotDue: 2 });
+	});
+
+	test("marks a permanent non-auth 4xx response as failed", async () => {
+		const repository = new MemoryOutboxRepository([progressRecord]);
+		const handlers = createHandlers();
+		handlers.progress.mockResolvedValue({
+			status: 422,
+			statusText: "Invalid page",
+		});
+		const engine = createOutboxReplayEngine({
+			repository,
+			handlers,
+			onAuthInvalid: vi.fn(),
+			now: () => new Date("2026-08-16T12:00:00.000Z"),
+		});
+
+		const summary = await engine.replay();
+
+		expect(summary.failed).toBe(1);
+		expect(repository.records.get(progressRecord.id)).toMatchObject({
+			attempts: 1,
+			status: "failed",
+			lastError: "HTTP 422: Invalid page",
+			nextAttemptAt: undefined,
+		});
+		expect(await getOutboxCounts(repository)).toEqual({
+			pending: 0,
+			failed: 1,
+			total: 1,
+		});
+	});
+
+	test.each([
+		401, 403,
+	] as const)("invokes auth invalidation and stops replay on %s", async (status) => {
+		const repository = new MemoryOutboxRepository([
+			libraryRecord,
+			progressRecord,
+		]);
+		const onAuthInvalid = vi.fn();
+		const progressHandler = vi.fn(async () => ({ status: 204 }));
+		const engine = createOutboxReplayEngine({
+			repository,
+			handlers: {
+				progress: progressHandler,
+				"add-to-library": async () => ({ status }),
+			},
+			onAuthInvalid,
+		});
+
+		const summary = await engine.replay();
+
+		expect(summary).toMatchObject({ attempted: 1, authInvalid: true });
+		expect(onAuthInvalid).toHaveBeenCalledWith(libraryRecord, status);
+		expect(progressHandler).not.toHaveBeenCalled();
+		expect(repository.records.size).toBe(2);
+	});
+
+	test("does not overwrite a newer deduplicated mutation during replay", async () => {
+		const repository = new MemoryOutboxRepository([progressRecord]);
+		const response = deferred<{ status: number }>();
+		const engine = createOutboxReplayEngine({
+			repository,
+			handlers: {
+				progress: () => response.promise,
+				"add-to-library": async () => ({ status: 204 }),
+			},
+			onAuthInvalid: vi.fn(),
+		});
+
+		const replay = engine.replay();
+		await vi.waitFor(() => expect(engine.state.isReplaying).toBe(true));
+		const newerRecord: ProgressOutboxRecord = {
+			...progressRecord,
+			id: "progress-2",
+			updatedAt: "2026-08-16T11:00:00.000Z",
+			payload: {
+				...progressRecord.payload,
+				currentPage: 20,
+				updatedAt: "2026-08-16T11:00:00.000Z",
+			},
+		};
+		await repository.put(newerRecord);
+		response.resolve({ status: 503 });
+
+		const summary = await replay;
+
+		expect(summary).toMatchObject({ superseded: 1, retryScheduled: 0 });
+		expect([...repository.records.values()]).toEqual([newerRecord]);
+	});
+
+	test("coalesces concurrent replay calls", async () => {
+		const repository = new MemoryOutboxRepository([progressRecord]);
+		const response = deferred<{ status: number }>();
+		const handler = vi.fn(() => response.promise);
+		const engine = createOutboxReplayEngine({
+			repository,
+			handlers: {
+				progress: handler,
+				"add-to-library": async () => ({ status: 204 }),
+			},
+			onAuthInvalid: vi.fn(),
+		});
+
+		const firstReplay = engine.replay();
+		const secondReplay = engine.replay();
+		expect(secondReplay).toBe(firstReplay);
+		response.resolve({ status: 204 });
+
+		await expect(firstReplay).resolves.toMatchObject({ succeeded: 1 });
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/lib/offline/outbox.ts
+++ b/src/lib/offline/outbox.ts
@@ -1,0 +1,355 @@
+import { offlineOutbox } from "./database";
+import type {
+	AddToLibraryOutboxRecord,
+	OfflineOutboxRecord,
+	ProgressOutboxRecord,
+} from "./types";
+
+export type OutboxHandlerResult = {
+	status: number;
+	statusText?: string;
+};
+
+export type OutboxReplayHandlers = {
+	progress: (record: ProgressOutboxRecord) => Promise<OutboxHandlerResult>;
+	"add-to-library": (
+		record: AddToLibraryOutboxRecord,
+	) => Promise<OutboxHandlerResult>;
+};
+
+export type OutboxRepository = {
+	getAll: () => Promise<OfflineOutboxRecord[]>;
+	getByDedupeKey: (
+		dedupeKey: string,
+	) => Promise<OfflineOutboxRecord | undefined>;
+	put: (record: OfflineOutboxRecord) => Promise<void>;
+	delete: (id: string) => Promise<void>;
+};
+
+export type OutboxCounts = {
+	pending: number;
+	failed: number;
+	total: number;
+};
+
+export type OutboxReplayState = {
+	isReplaying: boolean;
+	counts: OutboxCounts;
+};
+
+export type OutboxRecordOutcome =
+	| "succeeded"
+	| "retry-scheduled"
+	| "failed"
+	| "superseded";
+
+export type OutboxReplayEvent =
+	| {
+			type: "state";
+			state: OutboxReplayState;
+	  }
+	| {
+			type: "record";
+			record: OfflineOutboxRecord;
+			outcome: OutboxRecordOutcome;
+			state: OutboxReplayState;
+	  }
+	| {
+			type: "auth-invalid";
+			record: OfflineOutboxRecord;
+			status: 401 | 403;
+			state: OutboxReplayState;
+	  };
+
+export type OutboxReplaySummary = {
+	attempted: number;
+	succeeded: number;
+	retryScheduled: number;
+	failed: number;
+	superseded: number;
+	skippedNotDue: number;
+	authInvalid: boolean;
+};
+
+export type OutboxReplayOptions = {
+	handlers: OutboxReplayHandlers;
+	onAuthInvalid: (
+		record: OfflineOutboxRecord,
+		status: 401 | 403,
+	) => void | Promise<void>;
+	repository?: OutboxRepository;
+	now?: () => Date;
+	retryDelayMs?: (attempts: number) => number;
+};
+
+const EMPTY_COUNTS: OutboxCounts = { pending: 0, failed: 0, total: 0 };
+
+function defaultRetryDelayMs(attempts: number): number {
+	return Math.min(1_000 * 2 ** Math.max(0, attempts - 1), 5 * 60_000);
+}
+
+function describeError(error: unknown): string {
+	if (error instanceof Error && error.message) return error.message;
+	if (typeof error === "string" && error) return error;
+	return "Network request failed";
+}
+
+function describeResponse(response: OutboxHandlerResult): string {
+	return response.statusText
+		? `HTTP ${response.status}: ${response.statusText}`
+		: `HTTP ${response.status}`;
+}
+
+function sortRecords(records: OfflineOutboxRecord[]): OfflineOutboxRecord[] {
+	return [...records].sort(
+		(left, right) =>
+			left.createdAt.localeCompare(right.createdAt) ||
+			left.id.localeCompare(right.id),
+	);
+}
+
+function isDue(record: OfflineOutboxRecord, now: Date): boolean {
+	if (!record.nextAttemptAt) return true;
+	const nextAttempt = Date.parse(record.nextAttemptAt);
+	return Number.isNaN(nextAttempt) || nextAttempt <= now.getTime();
+}
+
+function isSameQueuedRecord(
+	queued: OfflineOutboxRecord | undefined,
+	replayed: OfflineOutboxRecord,
+): boolean {
+	return queued?.id === replayed.id && queued.updatedAt === replayed.updatedAt;
+}
+
+/** Count pending and permanently failed outbox records. */
+export async function getOutboxCounts(
+	repository: Pick<OutboxRepository, "getAll"> = offlineOutbox,
+): Promise<OutboxCounts> {
+	const records = await repository.getAll();
+	const pending = records.filter(({ status }) => status === "pending").length;
+	const failed = records.filter(({ status }) => status === "failed").length;
+	return { pending, failed, total: records.length };
+}
+
+/**
+ * Replays pending mutations serially in creation order.
+ *
+ * The engine is deliberately transport-agnostic: callers inject one handler
+ * for each mutation kind. A single engine instance coalesces concurrent
+ * `replay()` calls onto the same promise.
+ */
+export class OutboxReplayEngine {
+	readonly #handlers: OutboxReplayHandlers;
+	readonly #onAuthInvalid: OutboxReplayOptions["onAuthInvalid"];
+	readonly #repository: OutboxRepository;
+	readonly #now: () => Date;
+	readonly #retryDelayMs: (attempts: number) => number;
+	readonly #listeners = new Set<(event: OutboxReplayEvent) => void>();
+	#activeReplay: Promise<OutboxReplaySummary> | undefined;
+	#state: OutboxReplayState = {
+		isReplaying: false,
+		counts: EMPTY_COUNTS,
+	};
+
+	constructor(options: OutboxReplayOptions) {
+		this.#handlers = options.handlers;
+		this.#onAuthInvalid = options.onAuthInvalid;
+		this.#repository = options.repository ?? offlineOutbox;
+		this.#now = options.now ?? (() => new Date());
+		this.#retryDelayMs = options.retryDelayMs ?? defaultRetryDelayMs;
+	}
+
+	get state(): OutboxReplayState {
+		return {
+			isReplaying: this.#state.isReplaying,
+			counts: { ...this.#state.counts },
+		};
+	}
+
+	subscribe(listener: (event: OutboxReplayEvent) => void): () => void {
+		this.#listeners.add(listener);
+		return () => this.#listeners.delete(listener);
+	}
+
+	async refreshCounts(): Promise<OutboxReplayState> {
+		await this.#updateState(this.#state.isReplaying);
+		return this.state;
+	}
+
+	replay(): Promise<OutboxReplaySummary> {
+		if (this.#activeReplay) return this.#activeReplay;
+
+		const replay = this.#run().finally(() => {
+			this.#activeReplay = undefined;
+		});
+		this.#activeReplay = replay;
+		return replay;
+	}
+
+	async #run(): Promise<OutboxReplaySummary> {
+		const summary: OutboxReplaySummary = {
+			attempted: 0,
+			succeeded: 0,
+			retryScheduled: 0,
+			failed: 0,
+			superseded: 0,
+			skippedNotDue: 0,
+			authInvalid: false,
+		};
+
+		await this.#updateState(true);
+		try {
+			const records = sortRecords(await this.#repository.getAll()).filter(
+				({ status }) => status === "pending",
+			);
+
+			for (const record of records) {
+				if (!isDue(record, this.#now())) {
+					summary.skippedNotDue += 1;
+					continue;
+				}
+
+				summary.attempted += 1;
+				let response: OutboxHandlerResult;
+				try {
+					response = await this.#handle(record);
+				} catch (error) {
+					const outcome = await this.#scheduleRetry(
+						record,
+						describeError(error),
+					);
+					summary[outcome === "superseded" ? "superseded" : "retryScheduled"] +=
+						1;
+					await this.#emitRecord(record, outcome);
+					continue;
+				}
+
+				if (response.status >= 200 && response.status < 300) {
+					const outcome = await this.#deleteIfCurrent(record);
+					summary[outcome === "superseded" ? "superseded" : "succeeded"] += 1;
+					await this.#emitRecord(record, outcome);
+					continue;
+				}
+
+				if (response.status === 401 || response.status === 403) {
+					summary.authInvalid = true;
+					await this.#onAuthInvalid(record, response.status);
+					await this.#updateState(true);
+					this.#emit({
+						type: "auth-invalid",
+						record,
+						status: response.status,
+						state: this.state,
+					});
+					break;
+				}
+
+				if (response.status >= 400 && response.status < 500) {
+					const outcome = await this.#markFailed(
+						record,
+						describeResponse(response),
+					);
+					summary[outcome === "superseded" ? "superseded" : "failed"] += 1;
+					await this.#emitRecord(record, outcome);
+					continue;
+				}
+
+				const outcome = await this.#scheduleRetry(
+					record,
+					describeResponse(response),
+				);
+				summary[outcome === "superseded" ? "superseded" : "retryScheduled"] +=
+					1;
+				await this.#emitRecord(record, outcome);
+			}
+
+			return summary;
+		} finally {
+			await this.#updateState(false);
+		}
+	}
+
+	#handle(record: OfflineOutboxRecord): Promise<OutboxHandlerResult> {
+		if (record.kind === "progress") return this.#handlers.progress(record);
+		return this.#handlers["add-to-library"](record);
+	}
+
+	async #deleteIfCurrent(
+		record: OfflineOutboxRecord,
+	): Promise<"succeeded" | "superseded"> {
+		const current = await this.#repository.getByDedupeKey(record.dedupeKey);
+		if (!isSameQueuedRecord(current, record)) return "superseded";
+		await this.#repository.delete(record.id);
+		return "succeeded";
+	}
+
+	async #scheduleRetry(
+		record: OfflineOutboxRecord,
+		lastError: string,
+	): Promise<"retry-scheduled" | "superseded"> {
+		const current = await this.#repository.getByDedupeKey(record.dedupeKey);
+		if (!isSameQueuedRecord(current, record)) return "superseded";
+		const attempts = record.attempts + 1;
+		const now = this.#now();
+		await this.#repository.put({
+			...record,
+			attempts,
+			status: "pending",
+			updatedAt: now.toISOString(),
+			nextAttemptAt: new Date(
+				now.getTime() + Math.max(0, this.#retryDelayMs(attempts)),
+			).toISOString(),
+			lastError,
+		});
+		return "retry-scheduled";
+	}
+
+	async #markFailed(
+		record: OfflineOutboxRecord,
+		lastError: string,
+	): Promise<"failed" | "superseded"> {
+		const current = await this.#repository.getByDedupeKey(record.dedupeKey);
+		if (!isSameQueuedRecord(current, record)) return "superseded";
+		await this.#repository.put({
+			...record,
+			attempts: record.attempts + 1,
+			status: "failed",
+			updatedAt: this.#now().toISOString(),
+			nextAttemptAt: undefined,
+			lastError,
+		});
+		return "failed";
+	}
+
+	async #emitRecord(
+		record: OfflineOutboxRecord,
+		outcome: OutboxRecordOutcome,
+	): Promise<void> {
+		await this.#updateState(true);
+		this.#emit({ type: "record", record, outcome, state: this.state });
+	}
+
+	async #updateState(isReplaying: boolean): Promise<void> {
+		this.#state = {
+			isReplaying,
+			counts: await getOutboxCounts(this.#repository),
+		};
+		this.#emit({ type: "state", state: this.state });
+	}
+
+	#emit(event: OutboxReplayEvent): void {
+		for (const listener of this.#listeners) {
+			try {
+				listener(event);
+			} catch {
+				// A presentation listener must never interrupt synchronization.
+			}
+		}
+	}
+}
+
+export function createOutboxReplayEngine(
+	options: OutboxReplayOptions,
+): OutboxReplayEngine {
+	return new OutboxReplayEngine(options);
+}


### PR DESCRIPTION
## Summary

- add a transport-agnostic replay engine for queued offline mutations
- replay pending records serially in deterministic creation order
- coalesce concurrent replay calls and protect newer deduplicated mutations from stale in-flight results
- classify success, retryable network/5xx responses, permanent non-auth 4xx failures, and auth-invalid responses
- expose retry backoff metadata, queue counts, replay state, and subscribable record/auth events

## Why

Offline progress and library actions need one reliable replay primitive. Keeping policy in a generic engine lets later stack layers supply typed transports without duplicating ordering, retry, conflict, or auth-stop behavior.

## Stack

- **2 of 9**
- Depends on #252
- Base: `codex/offline-storage`
- Next: `codex/offline-comic-bundles`

## Validation

- `npm test` — 216 cumulative tests passed
- `npm run type:check:tsc`
