### PR TITLE
feat: make comic downloads atomic offline bundles

### DIFF
--- a/src/components/ComicCache/ComicCacheManager.browser.test.tsx
+++ b/src/components/ComicCache/ComicCacheManager.browser.test.tsx
@@ -1,132 +1,139 @@
+import type { OfflineComicRecord } from "@lib/offline/types";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { page } from "vitest/browser";
 import { render } from "vitest-browser-preact";
 
-vi.mock("./comicCache.utils", () => ({
-	deleteCachedIssue: vi.fn(),
-	listCachedComics: vi.fn(),
+vi.mock("@lib/offline/database", () => ({
+	isOfflineStorageSupported: vi.fn(() => true),
+	offlineComics: { getAll: vi.fn() },
 }));
 
-const { deleteCachedIssue, listCachedComics } = await import(
-	"./comicCache.utils"
+vi.mock("./comicCache.utils", () => ({
+	deleteCachedIssue: vi.fn(),
+}));
+
+const { isOfflineStorageSupported, offlineComics } = await import(
+	"@lib/offline/database"
 );
+const { deleteCachedIssue } = await import("./comicCache.utils");
 const { ComicCacheManager } = await import("./ComicCacheManager");
 
+const mockedStorageSupported = vi.mocked(isOfflineStorageSupported);
+const mockedGetAll = vi.mocked(offlineComics.getAll);
 const mockedDeleteCachedIssue = vi.mocked(deleteCachedIssue);
-const mockedListCachedComics = vi.mocked(listCachedComics);
+
+function comic(
+	issueId: string,
+	seriesName: string,
+	issueNumber: number | string,
+	overrides: Partial<OfflineComicRecord> = {},
+): OfflineComicRecord {
+	return {
+		issueId,
+		seriesId: `series-${seriesName}`,
+		seriesName,
+		issueNumber,
+		archiveCacheKey: `/api/comic/${issueId}/download`,
+		sizeBytes: 1024,
+		cachedAt: "2026-05-03T12:00:00.000Z",
+		updatedAt: "2026-05-03T12:00:00.000Z",
+		...overrides,
+	};
+}
 
 afterEach(() => {
 	vi.resetAllMocks();
+	mockedStorageSupported.mockReturnValue(true);
 });
 
 describe("ComicCacheManager", () => {
-	test("renders cached comics and deletes after confirmation", async () => {
-		mockedListCachedComics.mockResolvedValue([
-			{
-				issueId: "i1",
-				sizeBytes: 1024,
-				downloadUrl: "/api/comic/i1/download",
-				metadata: {
-					version: 1,
-					issueId: "i1",
-					seriesName: "Saga",
-					issueNumber: 1,
-					issueName: "One",
-					sizeBytes: 1024,
-					cachedAt: "2026-05-03T12:00:00.000Z",
-					downloadUrl: "/api/comic/i1/download",
-				},
-			},
+	test("reads canonical offline records and links directly to the reader", async () => {
+		mockedGetAll.mockResolvedValue([
+			comic("i1", "Saga", 1, {
+				issueName: "One",
+				coverCacheKey: "/covers/saga-1.jpg",
+			}),
 		]);
-		mockedDeleteCachedIssue.mockResolvedValue({
-			archiveDeleted: true,
-			metadataDeleted: true,
-		});
 
 		render(<ComicCacheManager />);
 
+		const issueLink = page.getByRole("link", { name: "Saga #1" });
+		await expect.element(issueLink).toBeInTheDocument();
+		await expect.element(issueLink).toHaveAttribute("href", "/comic/i1/read");
 		await expect
-			.element(page.getByRole("link", { name: "Saga #1" }))
-			.toBeInTheDocument();
+			.element(page.getByRole("img"))
+			.toHaveAttribute("src", "/covers/saga-1.jpg");
 		await expect
-			.element(page.getByText(/Cached 2026-05-03/))
+			.element(page.getByText(/Downloaded 2026-05-03/))
 			.toBeInTheDocument();
+		expect(mockedGetAll).toHaveBeenCalledOnce();
+	});
+
+	test("naturally orders issues and uses a placeholder without a cached cover", async () => {
+		mockedGetAll.mockResolvedValue([
+			comic("saga-10", "Saga", 10),
+			comic("monstress-1", "Monstress", 1),
+			comic("saga-2", "Saga", 2),
+		]);
+
+		render(<ComicCacheManager />);
+
+		const links = page.getByRole("link");
+		await expect.element(links.nth(0)).toHaveTextContent("Monstress #1");
+		await expect.element(links.nth(1)).toHaveTextContent("Saga #2");
+		await expect.element(links.nth(2)).toHaveTextContent("Saga #10");
+		await expect.element(page.getByRole("img")).not.toBeInTheDocument();
+	});
+
+	test("deletes a downloaded issue through the bundle deletion utility", async () => {
+		mockedGetAll.mockResolvedValue([comic("i1", "Saga", 1)]);
+		mockedDeleteCachedIssue.mockResolvedValue({
+			archiveDeleted: true,
+			metadataDeleted: true,
+			coverDeleted: false,
+		});
+
+		render(<ComicCacheManager />);
 
 		await page.getByRole("button", { name: "Delete Saga #1" }).click();
 		await page.getByRole("button", { name: "Confirm delete Saga #1" }).click();
 
 		expect(mockedDeleteCachedIssue).toHaveBeenCalledWith("i1");
 		await expect
-			.element(page.getByText("No comics are cached in this browser."))
+			.element(page.getByText("No comics are downloaded in this browser."))
 			.toBeInTheDocument();
 	});
 
-	test("renders and deletes a sidecar-less cached comic", async () => {
-		mockedListCachedComics.mockResolvedValue([
-			{
-				issueId: "legacy",
-				sizeBytes: 5,
-				downloadUrl: "/api/comic/legacy/download",
-				metadata: null,
-			},
-		]);
-		mockedDeleteCachedIssue.mockResolvedValue({
-			archiveDeleted: true,
-			metadataDeleted: false,
-		});
+	test("reports deletion failures without removing the local row", async () => {
+		mockedGetAll.mockResolvedValue([comic("i1", "Saga", 1)]);
+		mockedDeleteCachedIssue.mockRejectedValue(new Error("storage failure"));
 
 		render(<ComicCacheManager />);
 
+		await page.getByRole("button", { name: "Delete Saga #1" }).click();
+		await page.getByRole("button", { name: "Confirm delete Saga #1" }).click();
+
 		await expect
-			.element(page.getByRole("link", { name: "Issue legacy" }))
+			.element(
+				page
+					.getByRole("alert")
+					.getByText("The downloaded comic could not be deleted."),
+			)
 			.toBeInTheDocument();
-		await expect.element(page.getByText("Cached archive")).toBeInTheDocument();
-
-		await page.getByRole("button", { name: "Delete Issue legacy" }).click();
-		await page
-			.getByRole("button", { name: "Confirm delete Issue legacy" })
-			.click();
-
-		expect(mockedDeleteCachedIssue).toHaveBeenCalledWith("legacy");
 		await expect
-			.element(page.getByText("No comics are cached in this browser."))
+			.element(page.getByRole("link", { name: "Saga #1" }))
 			.toBeInTheDocument();
 	});
 
-	test("bulk deletes all selected cached comics after confirmation", async () => {
-		mockedListCachedComics.mockResolvedValue([
-			{
-				issueId: "i1",
-				sizeBytes: 1024,
-				downloadUrl: "/api/comic/i1/download",
-				metadata: {
-					version: 1,
-					issueId: "i1",
-					seriesName: "Saga",
-					issueNumber: 1,
-					sizeBytes: 1024,
-					cachedAt: "2026-05-03T12:00:00.000Z",
-					downloadUrl: "/api/comic/i1/download",
-				},
-			},
-			{
-				issueId: "i2",
-				sizeBytes: 2048,
-				downloadUrl: "/api/comic/i2/download",
-				metadata: {
-					version: 1,
-					issueId: "i2",
-					seriesName: "Saga",
-					issueNumber: 2,
-					sizeBytes: 2048,
-					cachedAt: "2026-05-03T12:00:00.000Z",
-					downloadUrl: "/api/comic/i2/download",
-				},
-			},
+	test("bulk deletes all selected downloaded comics after confirmation", async () => {
+		mockedGetAll.mockResolvedValue([
+			comic("i1", "Saga", 1),
+			comic("i2", "Saga", 2, { sizeBytes: 2048 }),
 		]);
 		mockedDeleteCachedIssue.mockResolvedValue({
 			archiveDeleted: true,
 			metadataDeleted: true,
+			coverDeleted: false,
 		});
 
 		render(<ComicCacheManager />);
@@ -135,17 +142,33 @@ describe("ComicCacheManager", () => {
 			.element(page.getByRole("link", { name: "Saga #1" }))
 			.toBeInTheDocument();
 		await page.getByLabelText("Select all").click();
-
-		const deleteSelectedButton = page.getByRole("button", { name: "Delete 2" });
-		await expect.element(deleteSelectedButton).toBeInTheDocument();
-		await deleteSelectedButton.click();
+		await page.getByRole("button", { name: "Delete 2" }).click();
 		await page.getByRole("button", { name: "Confirm delete" }).click();
 
 		expect(
 			mockedDeleteCachedIssue.mock.calls.map(([issueId]) => issueId),
 		).toEqual(["i1", "i2"]);
 		await expect
-			.element(page.getByText("No comics are cached in this browser."))
+			.element(page.getByText("No comics are downloaded in this browser."))
+			.toBeInTheDocument();
+	});
+
+	test("shows storage unsupported and read error states", async () => {
+		mockedStorageSupported.mockReturnValue(false);
+		const first = render(<ComicCacheManager />);
+		await expect
+			.element(page.getByText("Offline comic storage is unavailable"))
+			.toBeInTheDocument();
+		first.unmount();
+
+		mockedStorageSupported.mockReturnValue(true);
+		mockedGetAll.mockRejectedValue(new Error("IndexedDB failed"));
+		render(<ComicCacheManager />);
+		await expect
+			.element(page.getByText("Failed to read downloaded comics."))
+			.toBeInTheDocument();
+		await expect
+			.element(page.getByRole("button", { name: "Retry" }))
 			.toBeInTheDocument();
 	});
 });

--- a/src/components/ComicCache/ComicCacheManager.tsx
+++ b/src/components/ComicCache/ComicCacheManager.tsx
@@ -1,10 +1,11 @@
 import { Icon } from "@components/Icon/Icon";
-import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import {
-	type CachedComic,
-	deleteCachedIssue,
-	listCachedComics,
-} from "./comicCache.utils";
+	isOfflineStorageSupported,
+	offlineComics,
+} from "@lib/offline/database";
+import type { OfflineComicRecord } from "@lib/offline/types";
+import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
+import { deleteCachedIssue } from "./comicCache.utils";
 
 /** Loading state for the browser cache manager island. */
 type LoadState = "loading" | "ready" | "unsupported" | "error";
@@ -32,13 +33,8 @@ function formatBytes(bytes: number): string {
  * @param comic - Cached comic entry to label.
  * @returns Series/issue title, or an issue-id fallback for sidecar-less entries.
  */
-function formatIssueTitle(comic: CachedComic): string {
-	const metadata = comic.metadata;
-	if (!metadata) return `Issue ${comic.issueId}`;
-
-	const issueNumber =
-		metadata.issueNumber != null ? ` #${metadata.issueNumber}` : "";
-	return `${metadata.seriesName ?? "Comic"}${issueNumber}`;
+function formatIssueTitle(comic: OfflineComicRecord): string {
+	return `${comic.seriesName} #${comic.issueNumber}`;
 }
 
 /**
@@ -47,22 +43,40 @@ function formatIssueTitle(comic: CachedComic): string {
  * @param comic - Cached comic entry to summarize.
  * @returns Issue title/date/year details, or a fallback archive label.
  */
-function formatIssueMeta(comic: CachedComic): string {
-	const metadata = comic.metadata;
-	if (!metadata) return "Cached archive";
-
+function formatIssueMeta(comic: OfflineComicRecord): string {
 	const parts = [
-		metadata.issueName,
-		metadata.issueDate?.slice(0, 10),
-		metadata.seriesYear,
+		comic.issueName,
+		comic.issueDate?.slice(0, 10),
+		comic.seriesYear,
 	].filter(Boolean);
 
-	return parts.length > 0 ? parts.join(" · ") : "Cached archive";
+	return parts.length > 0 ? parts.join(" · ") : "Downloaded issue";
+}
+
+/** Canonical ordering for the local library: series, then natural issue number. */
+function sortOfflineComics(comics: OfflineComicRecord[]): OfflineComicRecord[] {
+	return [...comics].sort((left, right) => {
+		const bySeries = left.seriesName.localeCompare(
+			right.seriesName,
+			undefined,
+			{
+				sensitivity: "base",
+			},
+		);
+		if (bySeries !== 0) return bySeries;
+		const byIssue = String(left.issueNumber).localeCompare(
+			String(right.issueNumber),
+			undefined,
+			{ numeric: true, sensitivity: "base" },
+		);
+		return byIssue !== 0 ? byIssue : left.issueId.localeCompare(right.issueId);
+	});
 }
 
 /** Renders the browser cache management UI for cached comic archives. */
 export function ComicCacheManager() {
-	const [comics, setComics] = useState<CachedComic[]>([]);
+	const [comics, setComics] = useState<OfflineComicRecord[]>([]);
+	const [actionError, setActionError] = useState<string | null>(null);
 	const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
 	const [confirmingIssueId, setConfirmingIssueId] = useState<string | null>(
 		null,
@@ -72,18 +86,19 @@ export function ComicCacheManager() {
 	const [state, setState] = useState<LoadState>("loading");
 
 	const loadComics = useCallback(async () => {
-		if (typeof caches === "undefined") {
+		if (!isOfflineStorageSupported()) {
 			setState("unsupported");
 			return;
 		}
 
 		setState("loading");
 		setError(null);
+		setActionError(null);
 		setConfirmBulkDelete(false);
 		setConfirmingIssueId(null);
 
 		try {
-			const cachedComics = await listCachedComics();
+			const cachedComics = sortOfflineComics(await offlineComics.getAll());
 			setComics(cachedComics);
 			setSelectedIds((current) => {
 				const next = new Set<string>();
@@ -95,7 +110,7 @@ export function ComicCacheManager() {
 			});
 			setState("ready");
 		} catch {
-			setError("Failed to read the browser cache.");
+			setError("Failed to read downloaded comics.");
 			setState("error");
 		}
 	}, []);
@@ -146,17 +161,26 @@ export function ComicCacheManager() {
 	 * @param issueIds - Cached issue ids to remove.
 	 */
 	async function removeIssues(issueIds: string[]) {
-		await Promise.all(issueIds.map((issueId) => deleteCachedIssue(issueId)));
-		setComics((current) =>
-			current.filter((comic) => !issueIds.includes(comic.issueId)),
-		);
-		setSelectedIds((current) => {
-			const next = new Set(current);
-			for (const issueId of issueIds) next.delete(issueId);
-			return next;
-		});
-		setConfirmBulkDelete(false);
-		setConfirmingIssueId(null);
+		setActionError(null);
+		try {
+			await Promise.all(issueIds.map((issueId) => deleteCachedIssue(issueId)));
+			setComics((current) =>
+				current.filter((comic) => !issueIds.includes(comic.issueId)),
+			);
+			setSelectedIds((current) => {
+				const next = new Set(current);
+				for (const issueId of issueIds) next.delete(issueId);
+				return next;
+			});
+			setConfirmBulkDelete(false);
+			setConfirmingIssueId(null);
+		} catch {
+			setActionError(
+				issueIds.length === 1
+					? "The downloaded comic could not be deleted."
+					: "Some downloaded comics could not be deleted.",
+			);
+		}
 	}
 
 	/**
@@ -202,7 +226,7 @@ export function ComicCacheManager() {
 		return (
 			<div class="border border-slate-800 bg-slate-900 p-6">
 				<p class="text-sm text-slate-400">
-					Browser cache storage is unavailable in this context.
+					Offline comic storage is unavailable in this context.
 				</p>
 			</div>
 		);
@@ -225,6 +249,14 @@ export function ComicCacheManager() {
 
 	return (
 		<section class="flex flex-col gap-6">
+			{actionError && (
+				<div
+					role="alert"
+					class="border border-red-900 bg-red-950/40 px-4 py-3 text-sm text-red-300"
+				>
+					{actionError}
+				</div>
+			)}
 			<div class="grid gap-px overflow-hidden border border-slate-800 bg-slate-800 sm:grid-cols-3">
 				<div class="bg-slate-900 p-4">
 					<p class="text-[10px] font-bold uppercase tracking-widest text-slate-600">
@@ -286,7 +318,7 @@ export function ComicCacheManager() {
 			{comics.length === 0 ? (
 				<div class="border border-slate-800 bg-slate-900 p-8">
 					<p class="text-sm text-slate-500">
-						No comics are cached in this browser.
+						No comics are downloaded in this browser.
 					</p>
 				</div>
 			) : (
@@ -307,10 +339,10 @@ export function ComicCacheManager() {
 							</div>
 
 							<div class="h-20 w-14 overflow-hidden bg-slate-800 ring-1 ring-white/5">
-								{comic.metadata?.coverUrl ? (
+								{comic.coverCacheKey ? (
 									<img
-										src={comic.metadata.coverUrl}
-										alt=""
+										src={comic.coverCacheKey}
+										alt={`${formatIssueTitle(comic)} cover`}
 										class="h-full w-full object-cover"
 										loading="lazy"
 									/>
@@ -323,7 +355,7 @@ export function ComicCacheManager() {
 
 							<div class="min-w-0">
 								<a
-									href={`/comic/${comic.issueId}`}
+									href={`/comic/${encodeURIComponent(comic.issueId)}/read`}
 									class="block truncate text-sm font-bold text-white transition-colors hover:text-amber-400"
 								>
 									{formatIssueTitle(comic)}
@@ -333,9 +365,7 @@ export function ComicCacheManager() {
 								</p>
 								<p class="mt-2 text-[10px] font-bold uppercase tracking-widest text-slate-600">
 									{formatBytes(comic.sizeBytes)}
-									{comic.metadata?.cachedAt
-										? ` · Cached ${comic.metadata.cachedAt.slice(0, 10)}`
-										: ""}
+									{` · Downloaded ${comic.cachedAt.slice(0, 10)}`}
 								</p>
 							</div>
 

--- a/src/components/ComicCache/comicCache.utils.browser.test.ts
+++ b/src/components/ComicCache/comicCache.utils.browser.test.ts
@@ -1,15 +1,41 @@
+import { OFFLINE_COVER_CACHE_NAME } from "@lib/offline/cache-names";
+import type { OfflineComicRecord } from "@lib/offline/types";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const { offlineRecords } = vi.hoisted(() => ({
+	offlineRecords: new Map<string, OfflineComicRecord>(),
+}));
+
+vi.mock("@lib/offline/database", () => ({
+	offlineComics: {
+		get: vi.fn(async (issueId: string) => offlineRecords.get(issueId)),
+		put: vi.fn(async (record: OfflineComicRecord) => {
+			offlineRecords.set(record.issueId, record);
+		}),
+		delete: vi.fn(async (issueId: string) => {
+			offlineRecords.delete(issueId);
+		}),
+	},
+}));
+
+const { offlineComics } = await import("@lib/offline/database");
+
 import {
+	CACHED_COMIC_METADATA_VERSION,
 	COMIC_CACHE_NAME,
 	type ComicCacheMetadataInput,
 	deleteCachedIssue,
 	downloadIssueToCache,
+	getCachedComicCoverUrl,
 	getComicDownloadUrl,
 	getComicMetadataUrl,
 	isIssueCached,
+	LEGACY_COMIC_CACHE_NAME,
 	listCachedComics,
+	openComicCache,
 	parseIssueIdFromDownloadUrl,
 	readCachedComicMetadata,
+	retryCachedComicCover,
 	writeCachedComicMetadata,
 } from "./comicCache.utils";
 
@@ -20,8 +46,30 @@ function trackIssueId(issueId: string): string {
 	return issueId;
 }
 
-async function putArchive(issueId: string, bytes = new Uint8Array([1, 2, 3])) {
-	const cache = await caches.open(COMIC_CACHE_NAME);
+function metadataFor(
+	issueId: string,
+	overrides: Partial<ComicCacheMetadataInput> = {},
+): ComicCacheMetadataInput {
+	return {
+		issueId,
+		seriesId: "series-1",
+		seriesName: "Saga",
+		seriesYear: "2012",
+		issueNumber: 2,
+		issueName: "Chapter Two",
+		issueDate: "2026-01-02",
+		previousIssue: { issueId: "issue-1", issueNumber: 1 },
+		nextIssue: { issueId: "issue-3", issueNumber: 3 },
+		...overrides,
+	};
+}
+
+async function putArchive(
+	issueId: string,
+	bytes = new Uint8Array([1, 2, 3]),
+	cacheName = COMIC_CACHE_NAME,
+) {
+	const cache = await caches.open(cacheName);
 	await cache.put(
 		getComicDownloadUrl(issueId),
 		new Response(bytes, {
@@ -40,14 +88,65 @@ describe("comic cache utilities", () => {
 
 	afterEach(async () => {
 		fetchSpy.mockRestore();
-		const cache = await caches.open(COMIC_CACHE_NAME);
+		for (const cacheName of [COMIC_CACHE_NAME, LEGACY_COMIC_CACHE_NAME]) {
+			const cache = await caches.open(cacheName);
+			await Promise.all(
+				[...cleanupIds].flatMap((issueId) => [
+					cache.delete(getComicDownloadUrl(issueId)),
+					cache.delete(getComicMetadataUrl(issueId)),
+				]),
+			);
+		}
+		const coverCache = await caches.open(OFFLINE_COVER_CACHE_NAME);
 		await Promise.all(
-			[...cleanupIds].flatMap((issueId) => [
-				cache.delete(getComicDownloadUrl(issueId)),
-				cache.delete(getComicMetadataUrl(issueId)),
-			]),
+			[...cleanupIds].map((issueId) =>
+				coverCache.delete(getCachedComicCoverUrl(issueId)),
+			),
 		);
+		await Promise.all(
+			[...cleanupIds].map((issueId) => offlineComics.delete(issueId)),
+		);
+		offlineRecords.clear();
 		cleanupIds.clear();
+	});
+
+	test("migrates complete v1 bundles and preserves adjacency defaults", async () => {
+		const issueId = trackIssueId(`migration-${crypto.randomUUID()}`);
+		await caches.delete(COMIC_CACHE_NAME);
+		const legacy = await caches.open(LEGACY_COMIC_CACHE_NAME);
+		await putArchive(
+			issueId,
+			new Uint8Array([8, 6, 7, 5]),
+			LEGACY_COMIC_CACHE_NAME,
+		);
+		await legacy.put(
+			getComicMetadataUrl(issueId),
+			new Response(
+				JSON.stringify({
+					...metadataFor(issueId, {
+						previousIssue: undefined,
+						nextIssue: undefined,
+					}),
+					version: 1,
+					sizeBytes: 4,
+					cachedAt: "2025-01-01T00:00:00.000Z",
+					downloadUrl: getComicDownloadUrl(issueId),
+				}),
+			),
+		);
+
+		expect(await isIssueCached(issueId)).toBe(true);
+		expect(await readCachedComicMetadata(issueId)).toMatchObject({
+			version: CACHED_COMIC_METADATA_VERSION,
+			issueId,
+			previousIssue: null,
+			nextIssue: null,
+			cachedAt: "2025-01-01T00:00:00.000Z",
+		});
+		expect(await offlineComics.get(issueId)).toMatchObject({
+			issueId,
+			archiveCacheKey: getComicDownloadUrl(issueId),
+		});
 	});
 
 	test("parses issue IDs from archive cache keys", () => {
@@ -58,130 +157,234 @@ describe("comic cache utilities", () => {
 		expect(parseIssueIdFromDownloadUrl("/api/search?q=abc")).toBeNull();
 	});
 
-	test("writes, reads, lists, and deletes metadata sidecars", async () => {
+	test("writes, reads, lists, and deletes metadata with adjacency", async () => {
 		const issueId = trackIssueId(`sidecar-${crypto.randomUUID()}`);
 		const archiveBytes = await putArchive(
 			issueId,
 			new Uint8Array([1, 2, 3, 4]),
 		);
-
 		const written = await writeCachedComicMetadata(
-			{
-				issueId,
-				seriesId: "series-1",
-				seriesName: "Saga",
-				issueNumber: 1,
-				issueName: "One",
-				coverUrl: "/covers/issue.jpg",
-			},
+			metadataFor(issueId),
 			archiveBytes.byteLength,
 		);
 
-		expect(written?.issueId).toBe(issueId);
-		expect(written?.sizeBytes).toBe(4);
-
-		const read = await readCachedComicMetadata(issueId);
-		expect(read?.seriesName).toBe("Saga");
-
-		const comics = await listCachedComics();
-		const comic = comics.find((entry) => entry.issueId === issueId);
-		expect(comic).toMatchObject({
+		expect(written).toMatchObject({
 			issueId,
 			sizeBytes: 4,
-			metadata: expect.objectContaining({ issueName: "One" }),
+			previousIssue: { issueId: "issue-1", issueNumber: 1 },
+			nextIssue: { issueId: "issue-3", issueNumber: 3 },
+		});
+		const comics = await listCachedComics();
+		expect(comics.find((entry) => entry.issueId === issueId)).toMatchObject({
+			issueId,
+			sizeBytes: 4,
+			metadata: expect.objectContaining({ issueName: "Chapter Two" }),
+		});
+		expect(await offlineComics.get(issueId)).toMatchObject({
+			issueId,
+			seriesName: "Saga",
 		});
 
 		const result = await deleteCachedIssue(issueId);
-		expect(result.archiveDeleted).toBe(true);
-		expect(result.metadataDeleted).toBe(true);
-		expect(await isIssueCached(issueId)).toBe(false);
-		expect(await readCachedComicMetadata(issueId)).toBeNull();
-	});
-
-	test("lists sidecar-less archives without metadata", async () => {
-		const issueId = trackIssueId(`legacy-${crypto.randomUUID()}`);
-		await putArchive(issueId, new Uint8Array([5, 6, 7, 8, 9]));
-
-		const comics = await listCachedComics();
-		const comic = comics.find((entry) => entry.issueId === issueId);
-
-		expect(comic).toMatchObject({
-			issueId,
-			sizeBytes: 5,
-			metadata: null,
+		expect(result).toEqual({
+			archiveDeleted: true,
+			metadataDeleted: true,
+			coverDeleted: false,
 		});
+		expect(await isIssueCached(issueId)).toBe(false);
+		expect(await offlineComics.get(issueId)).toBeUndefined();
 	});
 
-	test("downloads archives and writes metadata on cache miss", async () => {
+	test("downloads and commits archive, metadata, and cover bytes", async () => {
 		const issueId = trackIssueId(`download-${crypto.randomUUID()}`);
+		const coverUrl = `/covers/${issueId}.jpg`;
 		const archiveBytes = new Uint8Array([9, 8, 7, 6]);
-
-		fetchSpy.mockResolvedValueOnce(
-			new Response(archiveBytes, {
-				status: 200,
-				headers: { "Content-Length": String(archiveBytes.byteLength) },
-			}),
-		);
+		fetchSpy
+			.mockResolvedValueOnce(
+				new Response(archiveBytes, {
+					status: 200,
+					headers: { "Content-Length": String(archiveBytes.byteLength) },
+				}),
+			)
+			.mockResolvedValueOnce(
+				new Response(new Uint8Array([4, 2]), { status: 200 }),
+			);
 
 		const progress: number[] = [];
 		const output = await downloadIssueToCache(
 			issueId,
 			(ratio) => progress.push(ratio),
-			{ issueId, seriesName: "Monstress", issueNumber: 2 },
+			metadataFor(issueId, { coverUrl }),
 		);
 
 		expect(output).toEqual(archiveBytes);
 		expect(progress.at(-1)).toBe(1);
 		expect(await isIssueCached(issueId)).toBe(true);
 		expect(await readCachedComicMetadata(issueId)).toMatchObject({
+			coverState: "cached",
+			coverCacheKey: getCachedComicCoverUrl(issueId),
+		});
+		expect(await offlineComics.get(issueId)).toMatchObject({
 			issueId,
-			seriesName: "Monstress",
-			issueNumber: 2,
-			sizeBytes: archiveBytes.byteLength,
+			seriesId: "series-1",
+			archiveCacheKey: getComicDownloadUrl(issueId),
+			coverCacheKey: getCachedComicCoverUrl(issueId),
+			nextIssue: { issueId: "issue-3", issueNumber: 3 },
+		});
+		const coverCache = await caches.open(OFFLINE_COVER_CACHE_NAME);
+		expect(
+			await coverCache.match(getCachedComicCoverUrl(issueId)),
+		).toBeTruthy();
+
+		const deleted = await deleteCachedIssue(issueId);
+		expect(deleted.coverDeleted).toBe(true);
+		expect(
+			await coverCache.match(getCachedComicCoverUrl(issueId)),
+		).toBeUndefined();
+		expect(await offlineComics.get(issueId)).toBeUndefined();
+	});
+
+	test("keeps a readable bundle with placeholder metadata when cover fails", async () => {
+		const issueId = trackIssueId(`cover-fail-${crypto.randomUUID()}`);
+		const coverUrl = `/covers/${issueId}.jpg`;
+		fetchSpy
+			.mockResolvedValueOnce(new Response(new Uint8Array([1, 3, 5, 7])))
+			.mockResolvedValueOnce(new Response("missing", { status: 503 }));
+
+		await downloadIssueToCache(
+			issueId,
+			() => {},
+			metadataFor(issueId, { coverUrl, coverThumbHash: "thumb" }),
+		);
+
+		expect(await isIssueCached(issueId)).toBe(true);
+		expect(await readCachedComicMetadata(issueId)).toMatchObject({
+			coverState: "pending",
+			coverThumbHash: "thumb",
+		});
+
+		fetchSpy.mockResolvedValueOnce(
+			new Response(new Uint8Array([2, 4, 6]), { status: 200 }),
+		);
+		await expect(retryCachedComicCover(issueId)).resolves.toBe(true);
+		expect(await readCachedComicMetadata(issueId)).toMatchObject({
+			coverState: "cached",
+			coverCacheKey: getCachedComicCoverUrl(issueId),
 		});
 	});
 
-	test("keeps the archive cached when metadata sidecar serialization fails", async () => {
+	test("rejects invalid required metadata before fetching or writing", async () => {
+		const issueId = trackIssueId(`invalid-${crypto.randomUUID()}`);
+		await expect(
+			downloadIssueToCache(issueId, () => {}, {
+				issueId,
+				seriesName: "Saga",
+				issueNumber: 1,
+			}),
+		).rejects.toThrow("requires issue, series, and issue-number fields");
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(await isIssueCached(issueId)).toBe(false);
+	});
+
+	test("rolls back the archive when required metadata cannot serialize", async () => {
 		const issueId = trackIssueId(`metadata-fail-${crypto.randomUUID()}`);
-		const archiveBytes = new Uint8Array([1, 3, 5, 7]);
 		type CircularMetadata = ComicCacheMetadataInput & {
 			self?: CircularMetadata;
 		};
-		const circularMetadata: CircularMetadata = { issueId, seriesName: "Saga" };
+		const circularMetadata: CircularMetadata = metadataFor(issueId);
 		circularMetadata.self = circularMetadata;
+		fetchSpy.mockResolvedValueOnce(new Response(new Uint8Array([1, 3, 5, 7])));
 
-		fetchSpy.mockResolvedValueOnce(
-			new Response(archiveBytes, {
-				status: 200,
-				headers: { "Content-Length": String(archiveBytes.byteLength) },
-			}),
-		);
-
-		const output = await downloadIssueToCache(
-			issueId,
-			() => {},
-			circularMetadata,
-		);
-
-		expect(output).toEqual(archiveBytes);
-		expect(await isIssueCached(issueId)).toBe(true);
+		await expect(
+			downloadIssueToCache(issueId, () => {}, circularMetadata),
+		).rejects.toThrow();
+		expect(await isIssueCached(issueId)).toBe(false);
 		expect(await readCachedComicMetadata(issueId)).toBeNull();
 	});
 
-	test("returns cached archives without fetching", async () => {
-		const issueId = trackIssueId(`hit-${crypto.randomUUID()}`);
+	test("rolls back metadata and cover when the archive commit fails", async () => {
+		const issueId = trackIssueId(`archive-fail-${crypto.randomUUID()}`);
+		const coverUrl = `/covers/${issueId}.jpg`;
+		fetchSpy
+			.mockResolvedValueOnce(new Response(new Uint8Array([1, 2, 3])))
+			.mockResolvedValueOnce(new Response(new Uint8Array([4, 5])));
+		const cache = await openComicCache();
+		expect(cache).not.toBeNull();
+		const cachePrototype = Object.getPrototypeOf(cache) as Cache;
+		const originalPut = cachePrototype.put;
+		const putSpy = vi
+			.spyOn(cachePrototype, "put")
+			.mockImplementation(async function (
+				this: Cache,
+				request: RequestInfo | URL,
+				response: Response,
+			) {
+				const url =
+					typeof request === "string"
+						? request
+						: request instanceof Request
+							? request.url
+							: request.toString();
+				if (url.endsWith(`/api/comic/${issueId}/download`)) {
+					throw new Error("quota exceeded");
+				}
+				return originalPut.call(this, request, response);
+			});
+
+		await expect(
+			downloadIssueToCache(
+				issueId,
+				() => {},
+				metadataFor(issueId, { coverUrl }),
+			),
+		).rejects.toThrow("quota exceeded");
+		putSpy.mockRestore();
+		const coverCache = await caches.open(OFFLINE_COVER_CACHE_NAME);
+		expect(await cache?.match(getComicDownloadUrl(issueId))).toBeUndefined();
+		expect(await cache?.match(getComicMetadataUrl(issueId))).toBeUndefined();
+		expect(
+			await coverCache.match(getCachedComicCoverUrl(issueId)),
+		).toBeUndefined();
+		expect(await offlineComics.get(issueId)).toBeUndefined();
+	});
+
+	test("rolls back Cache Storage when the searchable metadata write fails", async () => {
+		const issueId = trackIssueId(`idb-fail-${crypto.randomUUID()}`);
+		const coverUrl = `/covers/${issueId}.jpg`;
+		fetchSpy
+			.mockResolvedValueOnce(new Response(new Uint8Array([1, 2, 3])))
+			.mockResolvedValueOnce(new Response(new Uint8Array([4, 5])));
+		const putSpy = vi
+			.spyOn(offlineComics, "put")
+			.mockRejectedValueOnce(new Error("IndexedDB quota exceeded"));
+
+		await expect(
+			downloadIssueToCache(
+				issueId,
+				() => {},
+				metadataFor(issueId, { coverUrl }),
+			),
+		).rejects.toThrow("IndexedDB quota exceeded");
+		putSpy.mockRestore();
+		const cache = await caches.open(COMIC_CACHE_NAME);
+		const coverCache = await caches.open(OFFLINE_COVER_CACHE_NAME);
+		expect(await cache.match(getComicDownloadUrl(issueId))).toBeUndefined();
+		expect(await cache.match(getComicMetadataUrl(issueId))).toBeUndefined();
+		expect(
+			await coverCache.match(getCachedComicCoverUrl(issueId)),
+		).toBeUndefined();
+	});
+
+	test("keeps sidecar-less legacy archives readable but not complete", async () => {
+		const issueId = trackIssueId(`legacy-${crypto.randomUUID()}`);
 		const archiveBytes = await putArchive(
 			issueId,
 			new Uint8Array([4, 3, 2, 1]),
 		);
-
-		const progress: number[] = [];
-		const output = await downloadIssueToCache(issueId, (ratio) =>
-			progress.push(ratio),
-		);
+		const output = await downloadIssueToCache(issueId, () => {});
 
 		expect(output).toEqual(archiveBytes);
 		expect(fetchSpy).not.toHaveBeenCalled();
-		expect(progress).toEqual([1]);
+		expect(await isIssueCached(issueId)).toBe(false);
 	});
 });

--- a/src/components/ComicCache/comicCache.utils.ts
+++ b/src/components/ComicCache/comicCache.utils.ts
@@ -1,97 +1,100 @@
-/** Cache Storage bucket used for downloaded CBZ archives and metadata sidecars. */
-export const COMIC_CACHE_NAME = "comic-reader-v1";
+import {
+	COMIC_ARCHIVE_CACHE_NAME,
+	LEGACY_COMIC_ARCHIVE_CACHE_NAME,
+	OFFLINE_COVER_CACHE_NAME,
+} from "@lib/offline/cache-names";
+import { offlineComics } from "@lib/offline/database";
+import type { OfflineComicRecord } from "@lib/offline/types";
+
+/** Current Cache Storage bucket for complete offline comic bundles. */
+export const COMIC_CACHE_NAME = COMIC_ARCHIVE_CACHE_NAME;
+
+/** Previous cache bucket retained as a read/migration source. */
+export const LEGACY_COMIC_CACHE_NAME = LEGACY_COMIC_ARCHIVE_CACHE_NAME;
 
 /** Schema version for cached comic metadata sidecar responses. */
-export const CACHED_COMIC_METADATA_VERSION = 1;
+export const CACHED_COMIC_METADATA_VERSION = 2;
 
-/**
- * Metadata passed in when caching a comic issue.
- *
- * These fields are copied from Elasticsearch while the issue is already being
- * rendered or downloaded so cache-management UI can avoid extra API lookups.
- */
-export type ComicCacheMetadataInput = {
-	/** Stable issue id used by local cache keys and issue links. */
+const MIGRATION_MARKER_URL = "/offline/comics/migrations/v1-complete";
+
+/** Minimal server-derived reference used for true series adjacency. */
+export type CachedIssueReference = {
 	issueId: string;
-	/** Stable series id for grouping or linking back to the source series. */
-	seriesId?: string;
-	/** Human-readable series title displayed in cache lists and progress UI. */
-	seriesName?: string;
-	/** Series start year displayed as secondary issue metadata. */
-	seriesYear?: string;
-	/** Publisher issue number; may be numeric or a formatted string. */
-	issueNumber?: number | string;
-	/** Optional issue title displayed alongside the series and issue number. */
+	issueNumber: number | string;
 	issueName?: string;
-	/** Issue publication date as stored in Elasticsearch. */
+};
+
+/** Metadata passed in when caching a comic issue. */
+export type ComicCacheMetadataInput = {
+	issueId: string;
+	seriesId?: string;
+	seriesName?: string;
+	seriesYear?: string;
+	issueNumber?: number | string;
+	issueName?: string;
 	issueDate?: string;
-	/** Cover image URL used by the cache manager preview. */
 	coverUrl?: string;
-	/** ThumbHash placeholder for the issue cover, when available. */
 	coverThumbHash?: string;
+	/** Adjacent issues from the server's canonical series ordering. */
+	previousIssue?: CachedIssueReference | null;
+	nextIssue?: CachedIssueReference | null;
 };
 
 /** Metadata sidecar stored next to a cached CBZ archive. */
 export type CachedComicMetadata = ComicCacheMetadataInput & {
-	/** Sidecar schema version used to reject stale or incompatible metadata. */
 	version: typeof CACHED_COMIC_METADATA_VERSION;
-	/** Cached CBZ archive size in bytes. */
+	issueId: string;
+	seriesId: string;
+	seriesName: string;
+	issueNumber: number | string;
+	previousIssue: CachedIssueReference | null;
+	nextIssue: CachedIssueReference | null;
 	sizeBytes: number;
-	/** ISO timestamp for when the archive metadata was written. */
 	cachedAt: string;
-	/** Cache key URL for the archived CBZ download response. */
 	downloadUrl: string;
+	/** Original cover request key stored in Cache Storage when available. */
+	coverCacheKey?: string;
+	/** A failed cover fetch is retried on a later bundle access/download. */
+	coverState: "cached" | "pending" | "unavailable";
 };
 
 /** Browser-cache entry shown by the cache management page. */
 export type CachedComic = {
-	/** Stable issue id parsed from the cached download URL. */
 	issueId: string;
-	/** Cached archive size in bytes, from metadata or measured from the archive. */
 	sizeBytes: number;
-	/** Cache key URL for the archived CBZ download response. */
 	downloadUrl: string;
-	/** Metadata sidecar when present; null for sidecar-less legacy cache entries. */
 	metadata: CachedComicMetadata | null;
 };
 
-/** Result of removing an issue's archive and metadata sidecar from Cache Storage. */
+/** Result of removing all records belonging to one offline comic bundle. */
 export type CacheDeleteResult = {
-	/** Whether the cached CBZ archive response was removed. */
 	archiveDeleted: boolean;
-	/** Whether the cached metadata sidecar response was removed. */
 	metadataDeleted: boolean;
+	coverDeleted: boolean;
 };
 
-/**
- * Builds the Cache Storage key and API route for an issue's CBZ archive.
- *
- * @param issueId - Issue id to encode into the download URL.
- * @returns The relative download URL used as the archive cache key.
- */
+type LegacyCachedComicMetadata = ComicCacheMetadataInput & {
+	version: 1;
+	sizeBytes: number;
+	cachedAt: string;
+	downloadUrl: string;
+};
+
+let migrationPromise: Promise<void> | null = null;
+
 export function getComicDownloadUrl(issueId: string): string {
 	return `/api/comic/${encodeURIComponent(issueId)}/download`;
 }
 
-/**
- * Builds the Cache Storage key for an issue's metadata sidecar.
- *
- * @param issueId - Issue id to encode into the metadata URL.
- * @returns The relative sidecar URL used as the metadata cache key.
- */
 export function getComicMetadataUrl(issueId: string): string {
 	return `/api/comic/${encodeURIComponent(issueId)}/cache-metadata`;
 }
 
-/**
- * Extracts an issue id from a cached archive request.
- *
- * Only archive download keys match; metadata sidecar keys intentionally return
- * null so cache listings do not duplicate an issue.
- *
- * @param input - Cached request or URL string to inspect.
- * @returns The decoded issue id, or null when the URL is not an archive key.
- */
+/** Same-origin request key used to serve a cached cover while offline. */
+export function getCachedComicCoverUrl(issueId: string): string {
+	return `/offline/comics/${encodeURIComponent(issueId)}/cover`;
+}
+
 export function parseIssueIdFromDownloadUrl(
 	input: string | Request,
 ): string | null {
@@ -109,141 +112,329 @@ export function parseIssueIdFromDownloadUrl(
 	}
 }
 
-/**
- * Opens the browser Cache Storage bucket for comic archives.
- *
- * @returns The cache bucket, or null when Cache Storage is unavailable.
- */
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function isIssueReference(value: unknown): value is CachedIssueReference {
+	if (!value || typeof value !== "object") return false;
+	const reference = value as Partial<CachedIssueReference>;
+	return (
+		isNonEmptyString(reference.issueId) &&
+		(typeof reference.issueNumber === "number" ||
+			isNonEmptyString(reference.issueNumber))
+	);
+}
+
+/** Validates the metadata required to identify and render a downloaded issue. */
+export function isValidComicCacheMetadataInput(
+	input: unknown,
+): input is ComicCacheMetadataInput & {
+	issueId: string;
+	seriesId: string;
+	seriesName: string;
+	issueNumber: number | string;
+} {
+	if (!input || typeof input !== "object") return false;
+	const metadata = input as ComicCacheMetadataInput;
+	return (
+		isNonEmptyString(metadata.issueId) &&
+		isNonEmptyString(metadata.seriesId) &&
+		isNonEmptyString(metadata.seriesName) &&
+		(typeof metadata.issueNumber === "number" ||
+			isNonEmptyString(metadata.issueNumber)) &&
+		(metadata.previousIssue == null ||
+			isIssueReference(metadata.previousIssue)) &&
+		(metadata.nextIssue == null || isIssueReference(metadata.nextIssue))
+	);
+}
+
+function isCachedComicMetadata(
+	value: unknown,
+	issueId: string,
+): value is CachedComicMetadata {
+	if (!isValidComicCacheMetadataInput(value)) return false;
+	const metadata = value as Partial<CachedComicMetadata>;
+	return (
+		metadata.version === CACHED_COMIC_METADATA_VERSION &&
+		metadata.issueId === issueId &&
+		typeof metadata.sizeBytes === "number" &&
+		Number.isFinite(metadata.sizeBytes) &&
+		metadata.sizeBytes >= 0 &&
+		isNonEmptyString(metadata.cachedAt) &&
+		metadata.downloadUrl === getComicDownloadUrl(issueId) &&
+		(metadata.coverState === "cached" ||
+			metadata.coverState === "pending" ||
+			metadata.coverState === "unavailable")
+	);
+}
+
+function buildCachedMetadata(
+	input: ComicCacheMetadataInput,
+	sizeBytes: number,
+	coverState?: CachedComicMetadata["coverState"],
+): CachedComicMetadata {
+	if (!isValidComicCacheMetadataInput(input)) {
+		throw new Error(
+			"Comic cache metadata requires issue, series, and issue-number fields.",
+		);
+	}
+	if (!Number.isFinite(sizeBytes) || sizeBytes < 0) {
+		throw new Error("Comic archive size must be a non-negative number.");
+	}
+
+	const resolvedCoverState =
+		coverState ?? (input.coverUrl ? "pending" : "unavailable");
+	return {
+		...input,
+		version: CACHED_COMIC_METADATA_VERSION,
+		issueId: input.issueId,
+		seriesId: input.seriesId,
+		seriesName: input.seriesName,
+		issueNumber: input.issueNumber,
+		previousIssue: input.previousIssue ?? null,
+		nextIssue: input.nextIssue ?? null,
+		sizeBytes,
+		cachedAt: new Date().toISOString(),
+		downloadUrl: getComicDownloadUrl(input.issueId),
+		coverCacheKey: resolvedCoverState === "cached" ? input.coverUrl : undefined,
+		coverState: resolvedCoverState,
+	};
+}
+
+function toOfflineComicRecord(
+	metadata: CachedComicMetadata,
+): OfflineComicRecord {
+	return {
+		issueId: metadata.issueId,
+		seriesId: metadata.seriesId,
+		seriesName: metadata.seriesName,
+		seriesYear: metadata.seriesYear,
+		issueNumber: metadata.issueNumber,
+		issueName: metadata.issueName,
+		issueDate: metadata.issueDate,
+		coverUrl: metadata.coverUrl,
+		coverCacheKey: metadata.coverCacheKey,
+		coverThumbHash: metadata.coverThumbHash,
+		archiveCacheKey: metadata.downloadUrl,
+		sizeBytes: metadata.sizeBytes,
+		cachedAt: metadata.cachedAt,
+		updatedAt: metadata.cachedAt,
+		previousIssue: metadata.previousIssue,
+		nextIssue: metadata.nextIssue,
+	};
+}
+
+async function ensureOfflineComicRecord(
+	metadata: CachedComicMetadata,
+): Promise<OfflineComicRecord> {
+	const existing = await offlineComics.get(metadata.issueId);
+	if (
+		existing &&
+		existing.archiveCacheKey === metadata.downloadUrl &&
+		existing.updatedAt === metadata.cachedAt
+	) {
+		return existing;
+	}
+	const record = toOfflineComicRecord(metadata);
+	await offlineComics.put(record);
+	return record;
+}
+
+async function migrateLegacyCache(target: Cache): Promise<void> {
+	if (await target.match(MIGRATION_MARKER_URL)) return;
+
+	const legacy = await caches.open(LEGACY_COMIC_CACHE_NAME);
+	const requests = await legacy.keys();
+	for (const request of requests) {
+		const issueId = parseIssueIdFromDownloadUrl(request);
+		if (!issueId || (await target.match(getComicDownloadUrl(issueId))))
+			continue;
+
+		const archive = await legacy.match(request);
+		if (!archive) continue;
+
+		const legacySidecar = await legacy.match(getComicMetadataUrl(issueId));
+		let upgraded: CachedComicMetadata | null = null;
+		if (legacySidecar) {
+			try {
+				const metadata =
+					(await legacySidecar.json()) as LegacyCachedComicMetadata;
+				if (
+					metadata.version === 1 &&
+					isValidComicCacheMetadataInput(metadata)
+				) {
+					upgraded = {
+						...buildCachedMetadata(
+							metadata,
+							metadata.sizeBytes,
+							metadata.coverUrl ? "pending" : "unavailable",
+						),
+						cachedAt: metadata.cachedAt,
+					};
+				}
+			} catch {
+				/* A sidecar-less archive remains readable through legacy fallback. */
+			}
+		}
+
+		if (upgraded) {
+			try {
+				await target.put(
+					getComicMetadataUrl(issueId),
+					new Response(JSON.stringify(upgraded), {
+						headers: { "Content-Type": "application/json" },
+					}),
+				);
+				await ensureOfflineComicRecord(upgraded);
+				// The archive is committed last so the migrated bundle is never partial.
+				await target.put(getComicDownloadUrl(issueId), archive);
+			} catch (error) {
+				await Promise.allSettled([
+					target.delete(getComicDownloadUrl(issueId)),
+					target.delete(getComicMetadataUrl(issueId)),
+					offlineComics.delete(issueId),
+				]);
+				throw error;
+			}
+			continue;
+		}
+		// Incomplete legacy entries remain available for reader compatibility.
+		await target.put(getComicDownloadUrl(issueId), archive);
+	}
+
+	await target.put(MIGRATION_MARKER_URL, new Response("ok"));
+}
+
+/** Opens the current cache and performs the idempotent v1 migration once. */
 export async function openComicCache(): Promise<Cache | null> {
 	try {
-		if (typeof caches !== "undefined")
-			return await caches.open(COMIC_CACHE_NAME);
-	} catch {
-		/* Cache API unavailable (HTTP, older browser, quota/state issue). */
-	}
-	return null;
-}
-
-/**
- * Checks whether an issue archive is already cached in this browser.
- *
- * @param issueId - Issue id to look up in Cache Storage.
- * @returns True when the archive download response exists in the comic cache.
- */
-export async function isIssueCached(issueId: string): Promise<boolean> {
-	const cache = await openComicCache();
-	if (!cache) return false;
-	return Boolean(await cache.match(getComicDownloadUrl(issueId)));
-}
-
-/**
- * Reads and validates the metadata sidecar for a cached issue.
- *
- * @param issueId - Issue id whose sidecar should be read.
- * @returns Valid cached metadata, or null when absent, stale, or malformed.
- */
-export async function readCachedComicMetadata(
-	issueId: string,
-): Promise<CachedComicMetadata | null> {
-	const cache = await openComicCache();
-	if (!cache) return null;
-
-	const response = await cache.match(getComicMetadataUrl(issueId));
-	if (!response) return null;
-
-	try {
-		const metadata = (await response.json()) as CachedComicMetadata;
-		if (metadata.version !== CACHED_COMIC_METADATA_VERSION) return null;
-		if (metadata.issueId !== issueId) return null;
-		if (typeof metadata.sizeBytes !== "number") return null;
-		return metadata;
+		if (typeof caches === "undefined") return null;
+		const cache = await caches.open(COMIC_CACHE_NAME);
+		migrationPromise ??= migrateLegacyCache(cache).catch((error) => {
+			migrationPromise = null;
+			throw error;
+		});
+		await migrationPromise;
+		return cache;
 	} catch {
 		return null;
 	}
 }
 
-/**
- * Writes metadata for a cached issue archive.
- *
- * @param input - Issue metadata to persist beside the archive.
- * @param sizeBytes - Size of the cached archive in bytes.
- * @returns The metadata object that was written, or null when cache is unavailable.
- */
+/** Complete bundles require both the archive and valid current metadata. */
+export async function isIssueCached(issueId: string): Promise<boolean> {
+	const cache = await openComicCache();
+	if (!cache) return false;
+	const [archive, metadata, record] = await Promise.all([
+		cache.match(getComicDownloadUrl(issueId)),
+		readCachedComicMetadata(issueId, cache),
+		offlineComics.get(issueId),
+	]);
+	return Boolean(
+		archive &&
+			metadata &&
+			record?.archiveCacheKey === metadata.downloadUrl &&
+			record.updatedAt === metadata.cachedAt,
+	);
+}
+
+export async function readCachedComicMetadata(
+	issueId: string,
+	openedCache?: Cache,
+): Promise<CachedComicMetadata | null> {
+	const cache = openedCache ?? (await openComicCache());
+	if (!cache) return null;
+	const response = await cache.match(getComicMetadataUrl(issueId));
+	if (!response) return null;
+
+	try {
+		const metadata: unknown = await response.json();
+		return isCachedComicMetadata(metadata, issueId) ? metadata : null;
+	} catch {
+		return null;
+	}
+}
+
 export async function writeCachedComicMetadata(
 	input: ComicCacheMetadataInput,
 	sizeBytes: number,
+	coverState?: CachedComicMetadata["coverState"],
 ): Promise<CachedComicMetadata | null> {
+	const metadata = buildCachedMetadata(input, sizeBytes, coverState);
 	const cache = await openComicCache();
 	if (!cache) return null;
-
-	const metadata: CachedComicMetadata = {
-		...input,
-		version: CACHED_COMIC_METADATA_VERSION,
-		issueId: input.issueId,
-		sizeBytes,
-		cachedAt: new Date().toISOString(),
-		downloadUrl: getComicDownloadUrl(input.issueId),
-	};
-
 	await cache.put(
 		getComicMetadataUrl(input.issueId),
 		new Response(JSON.stringify(metadata), {
 			headers: { "Content-Type": "application/json" },
 		}),
 	);
-
 	return metadata;
 }
 
-/**
- * Writes cache metadata without letting sidecar failures block archive caching.
- *
- * @param input - Optional issue metadata to persist.
- * @param sizeBytes - Size of the cached archive in bytes.
- */
-async function writeCachedComicMetadataSafely(
-	input: ComicCacheMetadataInput | undefined,
-	sizeBytes: number,
-): Promise<void> {
-	if (!input) return;
+async function cacheCover(
+	metadata: CachedComicMetadata,
+): Promise<CachedComicMetadata> {
+	if (!metadata.coverUrl) return { ...metadata, coverState: "unavailable" };
+
 	try {
-		await writeCachedComicMetadata(input, sizeBytes);
+		const response = await fetch(metadata.coverUrl);
+		if (!response.ok) return { ...metadata, coverState: "pending" };
+		const coverCache = await caches.open(OFFLINE_COVER_CACHE_NAME);
+		const coverCacheKey = getCachedComicCoverUrl(metadata.issueId);
+		await coverCache.put(coverCacheKey, response);
+		return {
+			...metadata,
+			coverCacheKey,
+			coverState: "cached",
+		};
 	} catch {
-		/* Metadata sidecars are useful, but should not block reading. */
+		return { ...metadata, coverState: "pending" };
 	}
 }
 
-/**
- * Measures a cached archive response by reading its body.
- *
- * @param cache - Cache bucket containing the archive response.
- * @param request - Archive request key to measure.
- * @returns Archive size in bytes, or 0 when the response is missing.
- */
+/** Retries a previously failed optional cover write without affecting the bundle. */
+export async function retryCachedComicCover(issueId: string): Promise<boolean> {
+	const cache = await openComicCache();
+	if (!cache) return false;
+	const metadata = await readCachedComicMetadata(issueId, cache);
+	if (!metadata || metadata.coverState !== "pending") {
+		return metadata?.coverState === "cached";
+	}
+
+	const updated = await cacheCover(metadata);
+	if (updated.coverState !== "cached") return false;
+	try {
+		// Keep the sidecar pending when the searchable projection cannot update,
+		// so a later access can safely retry both writes.
+		await offlineComics.put(toOfflineComicRecord(updated));
+		await cache.put(
+			getComicMetadataUrl(issueId),
+			new Response(JSON.stringify(updated), {
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 async function getCachedArchiveSize(
 	cache: Cache,
 	request: Request,
 ): Promise<number> {
 	const response = await cache.match(request);
 	if (!response) return 0;
-	const buffer = await response.arrayBuffer();
-	return buffer.byteLength;
+	return (await response.arrayBuffer()).byteLength;
 }
 
-/**
- * Lists every comic archive cached in this browser.
- *
- * Sidecar-less archives are included with null metadata and their size measured
- * directly from the cached archive response.
- *
- * @returns Cached comics sorted by series, issue number, and issue id.
- */
 export async function listCachedComics(): Promise<CachedComic[]> {
 	const cache = await openComicCache();
 	if (!cache) return [];
 
-	const requests = await cache.keys();
-	const archiveRequests = requests
+	const archiveRequests = (await cache.keys())
 		.map((request) => ({
 			request,
 			issueId: parseIssueIdFromDownloadUrl(request),
@@ -255,12 +446,12 @@ export async function listCachedComics(): Promise<CachedComic[]> {
 
 	const comics = await Promise.all(
 		archiveRequests.map(async ({ request, issueId }) => {
-			const metadata = await readCachedComicMetadata(issueId);
-			const sizeBytes =
-				metadata?.sizeBytes ?? (await getCachedArchiveSize(cache, request));
+			const metadata = await readCachedComicMetadata(issueId, cache);
+			if (metadata) await ensureOfflineComicRecord(metadata);
 			return {
 				issueId,
-				sizeBytes,
+				sizeBytes:
+					metadata?.sizeBytes ?? (await getCachedArchiveSize(cache, request)),
 				downloadUrl: getComicDownloadUrl(issueId),
 				metadata,
 			};
@@ -268,9 +459,9 @@ export async function listCachedComics(): Promise<CachedComic[]> {
 	);
 
 	return comics.sort((a, b) => {
-		const aSeries = a.metadata?.seriesName ?? "";
-		const bSeries = b.metadata?.seriesName ?? "";
-		const bySeries = aSeries.localeCompare(bSeries);
+		const bySeries = (a.metadata?.seriesName ?? "").localeCompare(
+			b.metadata?.seriesName ?? "",
+		);
 		if (bySeries !== 0) return bySeries;
 		const aNumber = Number(a.metadata?.issueNumber ?? Number.MAX_SAFE_INTEGER);
 		const bNumber = Number(b.metadata?.issueNumber ?? Number.MAX_SAFE_INTEGER);
@@ -278,93 +469,96 @@ export async function listCachedComics(): Promise<CachedComic[]> {
 			Number.isFinite(aNumber) &&
 			Number.isFinite(bNumber) &&
 			aNumber !== bNumber
-		) {
+		)
 			return aNumber - bNumber;
-		}
 		return a.issueId.localeCompare(b.issueId);
 	});
 }
 
-/**
- * Deletes an issue's cached archive and metadata sidecar.
- *
- * @param issueId - Issue id to remove from Cache Storage.
- * @returns Flags indicating which cache entries were deleted.
- */
 export async function deleteCachedIssue(
 	issueId: string,
 ): Promise<CacheDeleteResult> {
 	const cache = await openComicCache();
-	if (!cache) return { archiveDeleted: false, metadataDeleted: false };
-
-	const [archiveDeleted, metadataDeleted] = await Promise.all([
+	if (!cache) {
+		await offlineComics.delete(issueId);
+		return {
+			archiveDeleted: false,
+			metadataDeleted: false,
+			coverDeleted: false,
+		};
+	}
+	const metadata = await readCachedComicMetadata(issueId, cache);
+	const coverCache = await caches.open(OFFLINE_COVER_CACHE_NAME);
+	const [archiveDeleted, metadataDeleted, coverDeleted] = await Promise.all([
 		cache.delete(getComicDownloadUrl(issueId)),
 		cache.delete(getComicMetadataUrl(issueId)),
+		metadata?.coverCacheKey
+			? coverCache.delete(metadata.coverCacheKey)
+			: Promise.resolve(false),
+		offlineComics.delete(issueId),
 	]);
-
-	return { archiveDeleted, metadataDeleted };
+	return { archiveDeleted, metadataDeleted, coverDeleted };
 }
 
-/**
- * Downloads an issue archive and stores it in the browser comic cache.
- *
- * Cache hits return the stored archive without a network request. Cache misses
- * stream progress when possible, store the archive response, and write metadata
- * as a best-effort sidecar.
- *
- * @param issueId - Issue id used to build the archive download URL.
- * @param onProgress - Called with a ratio in `[0, 1]` as bytes are received.
- * @param metadata - Optional metadata sidecar to write after caching the archive.
- * @returns The full CBZ archive bytes.
- * @throws If the download response is not OK or the response body cannot be read.
- */
-export async function downloadIssueToCache(
-	issueId: string,
-	onProgress: (ratio: number) => void,
-	metadata?: ComicCacheMetadataInput,
-): Promise<Uint8Array> {
-	const url = getComicDownloadUrl(issueId);
-	const cache = await openComicCache();
+async function commitBundle(
+	cache: Cache,
+	cbz: Uint8Array,
+	input: ComicCacheMetadataInput,
+): Promise<void> {
+	let metadata = buildCachedMetadata(input, cbz.byteLength);
+	metadata = await cacheCover(metadata);
 
-	if (cache) {
-		const cached = await cache.match(url);
-		if (cached) {
-			const buffer = await cached.arrayBuffer();
-			onProgress(1);
-			return new Uint8Array(buffer);
-		}
-	}
-
-	const response = await fetch(url);
-	if (!response.ok) {
-		const body = await response.json().catch(() => ({}));
-		throw new Error(
-			(body as { error?: string }).error ??
-				`Download failed (${response.status})`,
+	let metadataWritten = false;
+	try {
+		await cache.put(
+			getComicMetadataUrl(input.issueId),
+			new Response(JSON.stringify(metadata), {
+				headers: { "Content-Type": "application/json" },
+			}),
 		);
-	}
-
-	const contentLength = Number(response.headers.get("Content-Length") ?? 0);
-
-	if (!response.body) {
-		const buffer = await response.arrayBuffer();
-		onProgress(1);
-		const cbz = new Uint8Array(buffer);
-		if (cache) {
-			await cache.put(
-				url,
-				new Response(cbz, {
+		metadataWritten = true;
+		await offlineComics.put(toOfflineComicRecord(metadata));
+		await cache.put(
+			getComicDownloadUrl(input.issueId),
+			new Response(
+				cbz.buffer.slice(
+					cbz.byteOffset,
+					cbz.byteOffset + cbz.byteLength,
+				) as ArrayBuffer,
+				{
 					headers: { "Content-Type": "application/octet-stream" },
-				}),
-			);
-		}
-		await writeCachedComicMetadataSafely(metadata, cbz.byteLength);
+				},
+			),
+		);
+	} catch (error) {
+		const coverCache = await caches.open(OFFLINE_COVER_CACHE_NAME);
+		await Promise.allSettled([
+			cache.delete(getComicDownloadUrl(input.issueId)),
+			metadataWritten
+				? cache.delete(getComicMetadataUrl(input.issueId))
+				: Promise.resolve(false),
+			metadata.coverCacheKey
+				? coverCache.delete(metadata.coverCacheKey)
+				: Promise.resolve(false),
+			offlineComics.delete(input.issueId),
+		]);
+		throw error;
+	}
+}
+
+async function readDownloadResponse(
+	response: Response,
+	onProgress: (ratio: number) => void,
+): Promise<Uint8Array> {
+	const contentLength = Number(response.headers.get("Content-Length") ?? 0);
+	if (!response.body) {
+		const cbz = new Uint8Array(await response.arrayBuffer());
+		onProgress(1);
 		return cbz;
 	}
 
 	const chunks: Uint8Array[] = [];
 	let received = 0;
-
 	const reader = response.body.getReader();
 	while (true) {
 		const { done, value } = await reader.read();
@@ -380,16 +574,54 @@ export async function downloadIssueToCache(
 		cbz.set(chunk, offset);
 		offset += chunk.length;
 	}
+	return cbz;
+}
 
-	if (cache) {
-		await cache.put(
-			url,
-			new Response(cbz, {
-				headers: { "Content-Type": "application/octet-stream" },
-			}),
+/**
+ * Downloads and atomically commits the required archive + metadata records.
+ * Optional cover failures produce a readable bundle with a pending retry state.
+ */
+export async function downloadIssueToCache(
+	issueId: string,
+	onProgress: (ratio: number) => void,
+	metadata?: ComicCacheMetadataInput,
+): Promise<Uint8Array> {
+	const url = getComicDownloadUrl(issueId);
+	const cache = await openComicCache();
+	const cached = cache ? await cache.match(url) : undefined;
+	if (cached) {
+		const cbz = new Uint8Array(await cached.arrayBuffer());
+		const existingMetadata = cache
+			? await readCachedComicMetadata(issueId, cache)
+			: null;
+		if (!existingMetadata && metadata && cache) {
+			await commitBundle(cache, cbz, metadata);
+		} else if (existingMetadata) {
+			await ensureOfflineComicRecord(existingMetadata);
+			if (existingMetadata.coverState === "pending") {
+				void retryCachedComicCover(issueId);
+			}
+		}
+		onProgress(1);
+		return cbz;
+	}
+
+	if (!metadata || metadata.issueId !== issueId) {
+		throw new Error("Validated comic metadata is required before downloading.");
+	}
+	// Validate before starting the potentially large archive transfer.
+	buildCachedMetadata(metadata, 0);
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		const body = await response.json().catch(() => ({}));
+		throw new Error(
+			(body as { error?: string }).error ??
+				`Download failed (${response.status})`,
 		);
 	}
-	await writeCachedComicMetadataSafely(metadata, cbz.byteLength);
 
+	const cbz = await readDownloadResponse(response, onProgress);
+	if (cache) await commitBundle(cache, cbz, metadata);
 	return cbz;
 }

--- a/src/components/ComicReader/comicReader.utils.browser.test.ts
+++ b/src/components/ComicReader/comicReader.utils.browser.test.ts
@@ -1,5 +1,19 @@
+import {
+	COMIC_CACHE_NAME,
+	getComicMetadataUrl,
+	LEGACY_COMIC_CACHE_NAME,
+} from "@components/ComicCache/comicCache.utils";
 import { zipSync } from "fflate";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@lib/offline/database", () => ({
+	offlineComics: {
+		get: vi.fn(async () => undefined),
+		put: vi.fn(async () => undefined),
+		delete: vi.fn(async () => undefined),
+	},
+}));
+
 import {
 	downloadCbz,
 	extractPages,
@@ -93,12 +107,20 @@ describe("extractPages", () => {
 
 describe("downloadCbz", () => {
 	// Scope cache writes to a unique URL per test so they don't bleed across
-	// runs in the shared "comic-reader-v1" Cache Storage bucket.
+	// runs in the shared comic bundle Cache Storage buckets.
 	const issueId = `test-${crypto.randomUUID()}`;
 	const url = `/api/comic/${issueId}/download`;
 	const cbz = buildCbz({ "001.png": PNG_BYTES });
 
 	let fetchSpy: ReturnType<typeof vi.spyOn>;
+	const metadataFor = (id: string) => ({
+		issueId: id,
+		seriesId: "series-test",
+		seriesName: "Test Series",
+		issueNumber: 1,
+		previousIssue: null,
+		nextIssue: null,
+	});
 
 	beforeEach(() => {
 		fetchSpy = vi.spyOn(globalThis, "fetch");
@@ -108,10 +130,13 @@ describe("downloadCbz", () => {
 		fetchSpy.mockRestore();
 		// Clear any cache entries we wrote across all variants of this test's URL.
 		if (typeof caches !== "undefined") {
-			const cache = await caches.open("comic-reader-v1");
-			await cache.delete(url);
-			await cache.delete(`/api/comic/${issueId}-err/download`);
-			await cache.delete(`/api/comic/${issueId}-no-len/download`);
+			for (const cacheName of [COMIC_CACHE_NAME, LEGACY_COMIC_CACHE_NAME]) {
+				const cache = await caches.open(cacheName);
+				for (const id of [issueId, `${issueId}-err`, `${issueId}-no-len`]) {
+					await cache.delete(`/api/comic/${id}/download`);
+					await cache.delete(getComicMetadataUrl(id));
+				}
+			}
 		}
 	});
 
@@ -125,7 +150,11 @@ describe("downloadCbz", () => {
 		);
 
 		const progress: number[] = [];
-		const out = await downloadCbz(issueId, (r) => progress.push(r));
+		const out = await downloadCbz(
+			issueId,
+			(r) => progress.push(r),
+			metadataFor(issueId),
+		);
 
 		expect(out).toEqual(cbz);
 		expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -139,7 +168,7 @@ describe("downloadCbz", () => {
 
 	test("returns the cached archive without calling fetch on hit", async () => {
 		// Pre-populate the cache directly so we can prove fetch is bypassed.
-		const cache = await caches.open("comic-reader-v1");
+		const cache = await caches.open(COMIC_CACHE_NAME);
 		await cache.put(
 			url,
 			new Response(cbz.buffer as ArrayBuffer, {
@@ -168,7 +197,12 @@ describe("downloadCbz", () => {
 		fetchSpy.mockResolvedValueOnce(new Response(stream, { status: 200 }));
 
 		const progress: number[] = [];
-		const out = await downloadCbz(`${issueId}-no-len`, (r) => progress.push(r));
+		const noLengthId = `${issueId}-no-len`;
+		const out = await downloadCbz(
+			noLengthId,
+			(r) => progress.push(r),
+			metadataFor(noLengthId),
+		);
 
 		expect(out).toEqual(cbz);
 		expect(progress).toEqual([]);
@@ -182,8 +216,9 @@ describe("downloadCbz", () => {
 			}),
 		);
 
-		await expect(downloadCbz(`${issueId}-err`, () => {})).rejects.toThrow(
-			"boom",
-		);
+		const errorId = `${issueId}-err`;
+		await expect(
+			downloadCbz(errorId, () => {}, metadataFor(errorId)),
+		).rejects.toThrow("boom");
 	});
 });

--- a/src/data/comics.types.ts
+++ b/src/data/comics.types.ts
@@ -91,6 +91,10 @@ export type Issue = {
 	completed_at?: string;
 	/** Current page number the user is on (for resuming reading) */
 	current_page?: number;
+	/** Client timestamp used to resolve reading-progress conflicts. */
+	progress_updated_at?: string;
+	/** Idempotency id of the most recently applied progress mutation. */
+	progress_mutation_id?: string;
 	/** Whether the user has marked this issue as a favorite */
 	is_favorite?: boolean;
 	/** User's rating for this issue (1-5 stars) */

--- a/src/data/elastic/models/issue.model.ts
+++ b/src/data/elastic/models/issue.model.ts
@@ -76,6 +76,8 @@ export const issuesMappings: estypes.MappingTypeMapping = {
 		last_opened_at: { type: "date" }, // Most recent access
 		completed_at: { type: "date" }, // When marked as read
 		current_page: { type: "integer" }, // Resume reading from this page
+		progress_updated_at: { type: "date" }, // Client timestamp used for conflict resolution
+		progress_mutation_id: { type: "keyword" }, // Last applied idempotency key
 		is_favorite: { type: "boolean" },
 		user_rating: { type: "float" }, // 1-5 stars
 

--- a/src/data/elastic/queries.test.ts
+++ b/src/data/elastic/queries.test.ts
@@ -40,6 +40,71 @@ const nextIssue: Issue = {
 	synced_at: "2026-01-01T00:00:00.000Z",
 };
 
+describe("getSeriesCacheManifest", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test("uses server order and preserves gaps around downloaded issues", async () => {
+		elasticState.search.mockResolvedValueOnce({
+			hits: {
+				hits: [
+					{
+						_source: {
+							...currentIssue,
+							issue_id: "issue-1",
+							issue_number: 1,
+							series_name: "Saga",
+							series_year: "2012",
+							reading_state: "unread",
+						},
+					},
+					{
+						_source: {
+							...currentIssue,
+							issue_id: "issue-gap",
+							issue_number: 1.5,
+							download_status: "Wanted",
+						},
+					},
+					{
+						_source: {
+							...currentIssue,
+							issue_id: "issue-2",
+							issue_number: 2,
+							series_name: "Saga",
+							series_year: "2012",
+							reading_state: "read",
+						},
+					},
+				],
+			},
+		});
+
+		const result = await queries.getSeriesCacheManifest("series-1");
+
+		expect(result.downloadedIssues).toEqual([
+			expect.objectContaining({
+				issue_id: "issue-1",
+				previousIssue: null,
+				nextIssue: expect.objectContaining({ issue_id: "issue-gap" }),
+			}),
+			expect.objectContaining({
+				issue_id: "issue-2",
+				previousIssue: expect.objectContaining({ issue_id: "issue-gap" }),
+				nextIssue: null,
+			}),
+		]);
+		expect([...result.unreadDownloadedIssueIds]).toEqual(["issue-1"]);
+		expect(elasticState.search).toHaveBeenCalledWith(
+			expect.objectContaining({
+				query: { term: { series_id: "series-1" } },
+				sort: [{ issue_number: "asc" }, { issue_date: "asc" }],
+			}),
+		);
+	});
+});
+
 describe("getDownloadedSeriesIssues", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -212,5 +277,110 @@ describe("getNextDownloadedIssue", () => {
 		await expect(
 			queries.getNextDownloadedIssue(currentIssue),
 		).resolves.toBeNull();
+	});
+});
+
+describe("getAdjacentSeriesIssueReferences", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test("returns neighbours from server ordering without download filtering", async () => {
+		elasticState.search.mockResolvedValueOnce({
+			hits: {
+				hits: [
+					{
+						_source: { ...currentIssue, issue_id: "issue-1", issue_number: 1 },
+					},
+					{ _source: currentIssue },
+					{
+						_source: {
+							...nextIssue,
+							download_status: "Wanted",
+						},
+					},
+				],
+			},
+		});
+
+		await expect(
+			queries.getAdjacentSeriesIssueReferences(currentIssue),
+		).resolves.toEqual({
+			previousIssue: {
+				issue_id: "issue-1",
+				issue_number: 1,
+				issue_name: undefined,
+			},
+			nextIssue: {
+				issue_id: "issue-3",
+				issue_number: 3,
+				issue_name: undefined,
+			},
+		});
+		expect(elasticState.search).toHaveBeenCalledWith(
+			expect.objectContaining({
+				query: { term: { series_id: "series-1" } },
+				sort: [{ issue_number: "asc" }, { issue_date: "asc" }],
+			}),
+		);
+	});
+});
+
+describe("updateReadingProgress", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test("applies a strictly newer timestamp and stores its mutation id", async () => {
+		elasticState.update.mockResolvedValue({ result: "updated" });
+
+		await expect(
+			queries.updateReadingProgress("issue-2", {
+				currentPage: 12,
+				totalPages: 24,
+				updatedAt: "2026-08-16T12:34:56.000Z",
+				mutationId: "mutation-1",
+			}),
+		).resolves.toEqual({
+			applied: true,
+			updatedAt: "2026-08-16T12:34:56.000Z",
+		});
+
+		expect(elasticState.update).toHaveBeenCalledWith({
+			index: "issues",
+			id: "issue-2",
+			script: {
+				source: expect.stringMatching(
+					/progress_updated_at.*compareTo\(ctx\._source\.progress_updated_at\) <= 0/s,
+				),
+				params: {
+					current_page: 12,
+					total_pages: 24,
+					updated_at: "2026-08-16T12:34:56.000Z",
+					mutation_id: "mutation-1",
+				},
+			},
+		});
+	});
+
+	test("reports equal or older timestamps as stale when Elasticsearch no-ops", async () => {
+		elasticState.update.mockResolvedValue({ result: "noop" });
+
+		await expect(
+			queries.updateReadingProgress("issue-2", {
+				currentPage: 8,
+				totalPages: 24,
+				updatedAt: "2026-08-16T12:34:56.000Z",
+				mutationId: "mutation-replay",
+			}),
+		).resolves.toEqual({
+			applied: false,
+			updatedAt: "2026-08-16T12:34:56.000Z",
+		});
+
+		const source = elasticState.update.mock.calls[0][0].script.source as string;
+		expect(source).toContain("ctx.op = 'noop'");
+		expect(source).toContain("ctx._source.progress_mutation_id");
+		expect(source).toContain("ctx._source.last_opened_at = params.updated_at");
 	});
 });

--- a/src/data/elastic/queries.ts
+++ b/src/data/elastic/queries.ts
@@ -63,6 +63,31 @@ export type DownloadableIssueForCache = Pick<
 	| "issue_cover_thumb_hash"
 >;
 
+export type DownloadableIssueBundleMetadata = DownloadableIssueForCache & {
+	previousIssue: CacheIssueReference | null;
+	nextIssue: CacheIssueReference | null;
+};
+
+export type CacheIssueReference = Pick<
+	Issue,
+	"issue_id" | "issue_number" | "issue_name"
+>;
+
+type SeriesIssueForCache = Pick<
+	Issue,
+	| "issue_id"
+	| "series_id"
+	| "series_name"
+	| "series_year"
+	| "issue_number"
+	| "issue_name"
+	| "issue_date"
+	| "issue_cover_url"
+	| "issue_cover_thumb_hash"
+	| "download_status"
+	| "reading_state"
+>;
+
 type SortClause = Record<string, "asc" | "desc">;
 type HitWithSource<T> = { _source?: T };
 
@@ -84,6 +109,75 @@ const CACHE_ISSUE_SOURCE_FIELDS = [
 	"issue_cover_url",
 	"issue_cover_thumb_hash",
 ];
+
+const CACHE_MANIFEST_SOURCE_FIELDS = [
+	...CACHE_ISSUE_SOURCE_FIELDS,
+	"download_status",
+	"reading_state",
+];
+
+function toCacheIssueReference(
+	issue: SeriesIssueForCache,
+): CacheIssueReference {
+	return {
+		issue_id: issue.issue_id,
+		issue_number: issue.issue_number,
+		issue_name: issue.issue_name,
+	};
+}
+
+/**
+ * Builds complete metadata for downloaded issues using Elasticsearch's series
+ * order. Adjacent references include unavailable issues so offline navigation
+ * can distinguish a real series gap from the end of a series.
+ */
+export async function getSeriesCacheManifest(seriesId: string): Promise<{
+	downloadedIssues: DownloadableIssueBundleMetadata[];
+	unreadDownloadedIssueIds: Set<string>;
+}> {
+	const response = await elastic.search<SeriesIssueForCache>({
+		index: ISSUES_INDEX,
+		size: 1000,
+		query: { term: { series_id: seriesId } },
+		sort: [{ issue_number: "asc" }, { issue_date: "asc" }],
+		_source: CACHE_MANIFEST_SOURCE_FIELDS,
+	});
+
+	const ordered = hitSources(response.hits.hits);
+	const downloadedIssues = ordered.flatMap((issue, index) => {
+		if (issue.download_status !== "Downloaded") return [];
+		return [
+			{
+				issue_id: issue.issue_id,
+				series_id: issue.series_id,
+				series_name: issue.series_name,
+				series_year: issue.series_year,
+				issue_number: issue.issue_number,
+				issue_name: issue.issue_name,
+				issue_date: issue.issue_date,
+				issue_cover_url: issue.issue_cover_url,
+				issue_cover_thumb_hash: issue.issue_cover_thumb_hash,
+				previousIssue: ordered[index - 1]
+					? toCacheIssueReference(ordered[index - 1])
+					: null,
+				nextIssue: ordered[index + 1]
+					? toCacheIssueReference(ordered[index + 1])
+					: null,
+			},
+		];
+	});
+	const unreadDownloadedIssueIds = new Set(
+		ordered
+			.filter(
+				(issue) =>
+					issue.download_status === "Downloaded" &&
+					(issue.reading_state == null || issue.reading_state === "unread"),
+			)
+			.map((issue) => issue.issue_id),
+	);
+
+	return { downloadedIssues, unreadDownloadedIssueIds };
+}
 
 /**
  * Extracts present `_source` documents from Elasticsearch search hits.
@@ -231,6 +325,38 @@ export async function getIssue(issueId: string): Promise<Issue | null> {
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * Returns the true neighbours around an issue in Elasticsearch's canonical
+ * series order, regardless of whether either neighbour is downloaded.
+ */
+export async function getAdjacentSeriesIssueReferences(
+	currentIssue: Pick<Issue, "issue_id" | "series_id">,
+): Promise<{
+	previousIssue: CacheIssueReference | null;
+	nextIssue: CacheIssueReference | null;
+}> {
+	const response = await elastic.search<SeriesIssueForCache>({
+		index: ISSUES_INDEX,
+		size: 1000,
+		query: { term: { series_id: currentIssue.series_id } },
+		sort: [{ issue_number: "asc" }, { issue_date: "asc" }],
+		_source: CACHE_MANIFEST_SOURCE_FIELDS,
+	});
+	const ordered = hitSources(response.hits.hits);
+	const currentIndex = ordered.findIndex(
+		(issue) => issue.issue_id === currentIssue.issue_id,
+	);
+	if (currentIndex < 0) return { previousIssue: null, nextIssue: null };
+	return {
+		previousIssue: ordered[currentIndex - 1]
+			? toCacheIssueReference(ordered[currentIndex - 1])
+			: null,
+		nextIssue: ordered[currentIndex + 1]
+			? toCacheIssueReference(ordered[currentIndex + 1])
+			: null,
+	};
 }
 
 /**
@@ -543,36 +669,56 @@ export async function searchLibrarySeries(
 
 /**
  * Updates reading progress for an issue.
- * Handles state transitions: unread → reading → read, and sets timestamps.
+ * Handles state transitions and ignores stale or duplicate client updates.
  */
+export type UpdateReadingProgressInput = {
+	currentPage: number;
+	totalPages: number;
+	updatedAt: string;
+	mutationId: string;
+};
+
+export type UpdateReadingProgressResult = {
+	applied: boolean;
+	updatedAt: string;
+};
+
 export async function updateReadingProgress(
 	issueId: string,
-	currentPage: number,
-	totalPages: number,
-): Promise<void> {
-	await elastic.update({
+	input: UpdateReadingProgressInput,
+): Promise<UpdateReadingProgressResult> {
+	const response = await elastic.update({
 		index: ISSUES_INDEX,
 		id: issueId,
 		script: {
 			source: `
+        if (ctx._source.progress_updated_at != null && params.updated_at.compareTo(ctx._source.progress_updated_at) <= 0) {
+          ctx.op = 'noop';
+          return;
+        }
         ctx._source.current_page = params.current_page;
-        ctx._source.last_opened_at = params.now;
+		ctx._source.progress_updated_at = params.updated_at;
+		ctx._source.progress_mutation_id = params.mutation_id;
+        ctx._source.last_opened_at = params.updated_at;
         if (params.total_pages > 0 && params.current_page >= params.total_pages) {
           ctx._source.reading_state = 'read';
-          ctx._source.completed_at = params.now;
+		  ctx._source.completed_at = params.updated_at;
         } else if (params.current_page > 0) {
           ctx._source.reading_state = 'reading';
           ctx._source.completed_at = null;
         }
         if (ctx._source.started_reading_at == null && params.current_page > 0) {
-          ctx._source.started_reading_at = params.now;
+		  ctx._source.started_reading_at = params.updated_at;
         }
       `,
 			params: {
-				current_page: currentPage,
-				total_pages: totalPages,
-				now: new Date().toISOString(),
+				current_page: input.currentPage,
+				total_pages: input.totalPages,
+				updated_at: input.updatedAt,
+				mutation_id: input.mutationId,
 			},
 		},
 	});
+
+	return { applied: response.result !== "noop", updatedAt: input.updatedAt };
 }

--- a/src/pages/api/comic/[id]/progress.test.ts
+++ b/src/pages/api/comic/[id]/progress.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const queryMocks = vi.hoisted(() => ({
+	getIssue: vi.fn(),
+	updateReadingProgress: vi.fn(),
+}));
+
+vi.mock("@data/elastic/queries", () => queryMocks);
+
+const { PATCH, POST, handleProgress } = await import("./progress");
+
+const validBody = {
+	current_page: 12,
+	total_pages: 24,
+	updated_at: "2026-08-16T12:34:56.000Z",
+	mutation_id: "progress-device-a-123",
+};
+
+function request(body: unknown): Request {
+	return new Request("http://localhost/api/comic/issue-1/progress", {
+		method: "PATCH",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	queryMocks.getIssue.mockResolvedValue({ issue_id: "issue-1" });
+	queryMocks.updateReadingProgress.mockResolvedValue({
+		applied: true,
+		updatedAt: validBody.updated_at,
+	});
+});
+
+describe("progress API validation", () => {
+	test("rejects malformed JSON and non-object bodies", async () => {
+		const malformed = new Request("http://localhost", {
+			method: "PATCH",
+			body: "{",
+		});
+		expect((await handleProgress("issue-1", malformed)).status).toBe(400);
+		expect((await handleProgress("issue-1", request([]))).status).toBe(400);
+	});
+
+	test.each([
+		[{ ...validBody, current_page: 0 }, "current_page"],
+		[{ ...validBody, current_page: 1.5 }, "current_page"],
+		[{ ...validBody, total_pages: 0 }, "total_pages"],
+		[{ ...validBody, total_pages: 2.5 }, "total_pages"],
+		[{ ...validBody, current_page: 25 }, "cannot exceed"],
+		[{ ...validBody, updated_at: "2026-08-16" }, "updated_at"],
+		[{ ...validBody, updated_at: "not-a-date" }, "updated_at"],
+		[{ ...validBody, mutation_id: "" }, "mutation_id"],
+		[{ ...validBody, mutation_id: "x".repeat(201) }, "mutation_id"],
+	] as const)("rejects invalid progress fields", async (body, message) => {
+		const response = await handleProgress("issue-1", request(body));
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			error: expect.stringContaining(message),
+		});
+		expect(queryMocks.getIssue).not.toHaveBeenCalled();
+	});
+
+	test("returns 404 without attempting an update when the issue is missing", async () => {
+		queryMocks.getIssue.mockResolvedValue(null);
+
+		const response = await handleProgress("missing", request(validBody));
+
+		expect(response.status).toBe(404);
+		expect(queryMocks.updateReadingProgress).not.toHaveBeenCalled();
+	});
+});
+
+describe("progress API writes", () => {
+	test("normalizes the timestamp and reports an applied update", async () => {
+		const response = await handleProgress(
+			"issue-1",
+			request({
+				...validBody,
+				updated_at: "2026-08-16T13:34:56+01:00",
+			}),
+		);
+
+		expect(queryMocks.updateReadingProgress).toHaveBeenCalledWith("issue-1", {
+			currentPage: 12,
+			totalPages: 24,
+			updatedAt: "2026-08-16T12:34:56.000Z",
+			mutationId: validBody.mutation_id,
+		});
+		expect(await response.json()).toEqual({
+			ok: true,
+			applied: true,
+			stale: false,
+			current_page: validBody.current_page,
+			updated_at: validBody.updated_at,
+		});
+	});
+
+	test("returns authoritative server progress for an ignored timestamp", async () => {
+		queryMocks.getIssue
+			.mockResolvedValueOnce({ issue_id: "issue-1" })
+			.mockResolvedValueOnce({
+				issue_id: "issue-1",
+				current_page: 19,
+				progress_updated_at: "2026-08-16T13:00:00.000Z",
+			});
+		queryMocks.updateReadingProgress.mockResolvedValue({
+			applied: false,
+			updatedAt: validBody.updated_at,
+		});
+
+		const response = await handleProgress("issue-1", request(validBody));
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			applied: false,
+			stale: true,
+			current_page: 19,
+			updated_at: "2026-08-16T13:00:00.000Z",
+		});
+	});
+
+	test("returns 500 when Elasticsearch rejects the update", async () => {
+		queryMocks.updateReadingProgress.mockRejectedValue(
+			new Error("unavailable"),
+		);
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		const response = await handleProgress("issue-1", request(validBody));
+
+		expect(response.status).toBe(500);
+		consoleError.mockRestore();
+	});
+
+	test.each([
+		[PATCH, "PATCH"],
+		[POST, "POST"],
+	] as const)("supports %s route calls", async (route, method) => {
+		const response = await route({
+			params: { id: "issue-1" },
+			request: new Request("http://localhost", {
+				method,
+				body: JSON.stringify(validBody),
+			}),
+		} as unknown as Parameters<typeof route>[0]);
+
+		expect(response.status).toBe(200);
+	});
+});

--- a/src/pages/api/comic/[id]/progress.ts
+++ b/src/pages/api/comic/[id]/progress.ts
@@ -1,30 +1,43 @@
 import { getIssue, updateReadingProgress } from "@data/elastic/queries";
 import type { APIRoute } from "astro";
 
-async function handleProgress(id: string, request: Request): Promise<Response> {
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+function json(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: JSON_HEADERS,
+	});
+}
+
+function parseIsoTimestamp(value: unknown): string | null {
+	if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T/.test(value)) {
+		return null;
+	}
+	const timestamp = new Date(value);
+	return Number.isNaN(timestamp.getTime()) ? null : timestamp.toISOString();
+}
+
+export async function handleProgress(
+	id: string,
+	request: Request,
+): Promise<Response> {
 	let body: unknown;
 	try {
 		body = await request.json();
 	} catch {
-		return new Response(JSON.stringify({ error: "Invalid JSON" }), {
-			status: 400,
-			headers: { "Content-Type": "application/json" },
-		});
+		return json({ error: "Invalid JSON" }, 400);
 	}
 
 	if (typeof body !== "object" || body === null || Array.isArray(body)) {
-		return new Response(
-			JSON.stringify({ error: "Request body must be a JSON object" }),
-			{
-				status: 400,
-				headers: { "Content-Type": "application/json" },
-			},
-		);
+		return json({ error: "Request body must be a JSON object" }, 400);
 	}
 
-	const { current_page, total_pages } = body as {
+	const { current_page, total_pages, updated_at, mutation_id } = body as {
 		current_page?: number;
 		total_pages?: number;
+		updated_at?: unknown;
+		mutation_id?: unknown;
 	};
 
 	if (
@@ -32,56 +45,75 @@ async function handleProgress(id: string, request: Request): Promise<Response> {
 		!Number.isInteger(current_page) ||
 		current_page < 1
 	) {
-		return new Response(
-			JSON.stringify({ error: "current_page must be a positive integer" }),
+		return json({ error: "current_page must be a positive integer" }, 400);
+	}
+
+	if (
+		typeof total_pages !== "number" ||
+		!Number.isInteger(total_pages) ||
+		total_pages < 1
+	) {
+		return json({ error: "total_pages must be a positive integer" }, 400);
+	}
+
+	if (current_page > total_pages) {
+		return json({ error: "current_page cannot exceed total_pages" }, 400);
+	}
+
+	const normalizedUpdatedAt = parseIsoTimestamp(updated_at);
+	if (!normalizedUpdatedAt) {
+		return json({ error: "updated_at must be an ISO timestamp" }, 400);
+	}
+
+	if (
+		typeof mutation_id !== "string" ||
+		mutation_id.trim().length === 0 ||
+		mutation_id.length > 200
+	) {
+		return json(
 			{
-				status: 400,
-				headers: { "Content-Type": "application/json" },
+				error:
+					"mutation_id must be a non-empty string of at most 200 characters",
 			},
+			400,
 		);
 	}
 
 	const issue = await getIssue(id);
 	if (!issue) {
-		return new Response(JSON.stringify({ error: "Issue not found" }), {
-			status: 404,
-			headers: { "Content-Type": "application/json" },
-		});
+		return json({ error: "Issue not found" }, 404);
 	}
-
-	// Prefer client-reported total (actual extracted pages), fall back to ES metadata
-	const resolvedTotal =
-		typeof total_pages === "number" && total_pages > 0
-			? total_pages
-			: (issue.issue_page_count ?? 0);
 
 	try {
-		await updateReadingProgress(id, current_page, resolvedTotal);
+		const result = await updateReadingProgress(id, {
+			currentPage: current_page,
+			totalPages: total_pages,
+			updatedAt: normalizedUpdatedAt,
+			mutationId: mutation_id,
+		});
+		const authoritativeIssue = result.applied ? issue : await getIssue(id);
+		return json({
+			ok: true,
+			applied: result.applied,
+			stale: !result.applied,
+			current_page: result.applied
+				? current_page
+				: (authoritativeIssue?.current_page ?? current_page),
+			updated_at: result.applied
+				? result.updatedAt
+				: (authoritativeIssue?.progress_updated_at ?? result.updatedAt),
+		});
 	} catch (err) {
 		console.error("Failed to update reading progress:", err);
-		return new Response(
-			JSON.stringify({ error: "Failed to update progress" }),
-			{
-				status: 500,
-				headers: { "Content-Type": "application/json" },
-			},
-		);
+		return json({ error: "Failed to update progress" }, 500);
 	}
-
-	return new Response(JSON.stringify({ ok: true }), {
-		status: 200,
-		headers: { "Content-Type": "application/json" },
-	});
 }
 
 // PATCH for normal fetch calls
 export const PATCH: APIRoute = async ({ params, request }) => {
 	const { id } = params;
 	if (!id) {
-		return new Response(JSON.stringify({ error: "Missing issue ID" }), {
-			status: 400,
-			headers: { "Content-Type": "application/json" },
-		});
+		return json({ error: "Missing issue ID" }, 400);
 	}
 	return handleProgress(id, request);
 };
@@ -90,10 +122,7 @@ export const PATCH: APIRoute = async ({ params, request }) => {
 export const POST: APIRoute = async ({ params, request }) => {
 	const { id } = params;
 	if (!id) {
-		return new Response(JSON.stringify({ error: "Missing issue ID" }), {
-			status: 400,
-			headers: { "Content-Type": "application/json" },
-		});
+		return json({ error: "Missing issue ID" }, 400);
 	}
 	return handleProgress(id, request);
 };


### PR DESCRIPTION
## Summary

- introduce the validated `comic-reader-v2` bundle format: required CBZ archive, JSON metadata sidecar, and searchable IndexedDB projection
- commit required records atomically with rollback, while treating covers as optional best-effort data with placeholder state and retry support
- migrate sufficiently complete v1 sidecars forward without advertising incomplete legacy archives as complete bundles
- derive previous/next references from the server's canonical series order so gaps are preserved
- move the cached-comics manager onto canonical IndexedDB records and ensure deletion removes archive, metadata, cover, and projection together
- align the Elasticsearch mapping/query and progress endpoint with the timestamped metadata contract used by later synchronization layers

## Why

Offline navigation and reading need a trustworthy definition of "downloaded." This layer prevents partial downloads from appearing as readable comics and preserves the server's true issue ordering rather than guessing adjacency from locally available files.

## Stack

- **3 of 9**
- Depends on #253
- Base: `codex/offline-outbox`
- Next: `codex/offline-library-search`

## Validation

- `npm test` — 243 cumulative tests passed
- `npm run type:check:tsc`
