### PR TITLE
feat: search downloaded comics offline

### DIFF
--- a/src/components/SearchBar/SearchBar.browser.test.tsx
+++ b/src/components/SearchBar/SearchBar.browser.test.tsx
@@ -1,0 +1,226 @@
+import type { OfflineStatusSource } from "@lib/offline/search";
+import type { OfflineComicRecord } from "@lib/offline/types";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { page, userEvent } from "vitest/browser";
+import { render } from "vitest-browser-preact";
+
+vi.mock("@lib/offline/search", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@lib/offline/search")>();
+	return { ...actual, searchDownloadedComics: vi.fn() };
+});
+
+const { searchDownloadedComics } = await import("@lib/offline/search");
+const { SearchBar } = await import("./SearchBar");
+const mockedSearchDownloadedComics = vi.mocked(searchDownloadedComics);
+
+function comic(
+	issueId: string,
+	issueNumber: number,
+	overrides: Partial<OfflineComicRecord> = {},
+): OfflineComicRecord {
+	return {
+		issueId,
+		seriesId: "series-saga",
+		seriesName: "Saga",
+		issueNumber,
+		archiveCacheKey: `/api/comic/${issueId}/download`,
+		sizeBytes: 1024,
+		cachedAt: "2026-08-16T10:00:00.000Z",
+		updatedAt: "2026-08-16T10:00:00.000Z",
+		...overrides,
+	};
+}
+
+function connectivity(initiallyOffline: boolean): {
+	source: OfflineStatusSource;
+	setOffline: (offline: boolean) => void;
+} {
+	let offline = initiallyOffline;
+	const listeners = new Set<(offline: boolean) => void>();
+	return {
+		source: {
+			isOffline: () => offline,
+			subscribe: (listener) => {
+				listeners.add(listener);
+				return () => listeners.delete(listener);
+			},
+		},
+		setOffline: (nextOffline) => {
+			offline = nextOffline;
+			for (const listener of listeners) listener(offline);
+		},
+	};
+}
+
+function openSearch() {
+	window.dispatchEvent(new CustomEvent("open-search"));
+}
+
+afterEach(() => {
+	vi.resetAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("SearchBar", () => {
+	test("searches only downloaded metadata while offline", async () => {
+		const networkFetch = vi.fn();
+		vi.stubGlobal("fetch", networkFetch);
+		mockedSearchDownloadedComics.mockResolvedValue([
+			comic("issue/1", 1, {
+				issueName: "Chapter One",
+				seriesYear: "2012",
+				coverCacheKey: "/covers/saga-1.jpg",
+			}),
+		]);
+		const status = connectivity(true);
+		render(<SearchBar connectivity={status.source} />);
+		openSearch();
+
+		await expect
+			.element(page.getByText("Offline · Searching downloaded comics only"))
+			.toBeInTheDocument();
+		await page
+			.getByRole("searchbox", { name: "Search downloaded comics" })
+			.fill("Saga");
+
+		const result = page.getByRole("link", { name: /Saga #1/ });
+		await expect.element(result).toBeInTheDocument();
+		await expect
+			.element(result)
+			.toHaveAttribute("href", "/comic/issue%2F1/read");
+		await expect.element(result).toHaveTextContent("Downloaded");
+		await expect
+			.element(result.getByRole("img"))
+			.toHaveAttribute("src", "/covers/saga-1.jpg");
+		expect(mockedSearchDownloadedComics).toHaveBeenCalledWith("Saga");
+		expect(networkFetch).not.toHaveBeenCalled();
+	});
+
+	test("shows an offline empty state", async () => {
+		const status = connectivity(true);
+		mockedSearchDownloadedComics.mockResolvedValue([]);
+		render(<SearchBar connectivity={status.source} />);
+		openSearch();
+		const searchbox = page.getByRole("searchbox", {
+			name: "Search downloaded comics",
+		});
+		await searchbox.fill("Batman");
+		await expect
+			.element(page.getByText(/No downloaded comics for/))
+			.toBeInTheDocument();
+	});
+
+	test("shows local search errors", async () => {
+		const status = connectivity(true);
+		mockedSearchDownloadedComics.mockRejectedValue(
+			new Error("IndexedDB failed"),
+		);
+		render(<SearchBar connectivity={status.source} />);
+		openSearch();
+		await page
+			.getByRole("searchbox", { name: "Search downloaded comics" })
+			.fill("Saga");
+		await expect
+			.element(
+				page
+					.getByRole("alert")
+					.getByText("Downloaded comics could not be searched."),
+			)
+			.toBeInTheDocument();
+	});
+
+	test("preserves both online search sources and keyboard highlighting", async () => {
+		const networkFetch = vi.fn((input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.startsWith("/api/search/comicvine")) {
+				return Promise.resolve(
+					new Response(
+						JSON.stringify([
+							{
+								id: 200,
+								name: "Saga Deluxe",
+								start_year: "2013",
+							},
+						]),
+						{ status: 200 },
+					),
+				);
+			}
+			return Promise.resolve(
+				new Response(
+					JSON.stringify([
+						{
+							series_id: "100",
+							series_name: "Saga",
+							series_year: "2012",
+						},
+					]),
+					{ status: 200 },
+				),
+			);
+		});
+		vi.stubGlobal("fetch", networkFetch);
+		const status = connectivity(false);
+		render(<SearchBar connectivity={status.source} />);
+		openSearch();
+
+		const searchbox = page.getByRole("searchbox", { name: "Search series" });
+		await searchbox.fill("Saga");
+		const libraryResult = page.getByRole("link", { name: /^Saga 2012/ });
+		const comicVineResult = page.getByRole("link", {
+			name: /^Saga Deluxe 2013/,
+		});
+		await expect.element(libraryResult).toBeInTheDocument();
+		await expect.element(comicVineResult).toBeInTheDocument();
+		await expect.element(libraryResult).toHaveAttribute("href", "/series/100");
+		await searchbox.click();
+		await userEvent.keyboard("{ArrowDown}");
+		await expect.element(libraryResult).toHaveClass(/bg-slate-800/);
+		await userEvent.keyboard("{ArrowDown}");
+		await expect.element(comicVineResult).toHaveClass(/bg-slate-800/);
+		expect(networkFetch).toHaveBeenCalledTimes(2);
+		expect(mockedSearchDownloadedComics).not.toHaveBeenCalled();
+	});
+
+	test("switches an open dialog to local search when PWA status goes offline", async () => {
+		const networkFetch = vi.fn(() =>
+			Promise.resolve(new Response(JSON.stringify([]), { status: 200 })),
+		);
+		vi.stubGlobal("fetch", networkFetch);
+		mockedSearchDownloadedComics.mockResolvedValue([comic("issue-2", 2)]);
+		const status = connectivity(false);
+		render(<SearchBar connectivity={status.source} />);
+		openSearch();
+		await page.getByRole("searchbox", { name: "Search series" }).fill("Saga");
+		status.setOffline(true);
+
+		await expect
+			.element(
+				page.getByRole("searchbox", { name: "Search downloaded comics" }),
+			)
+			.toBeInTheDocument();
+		await expect
+			.element(page.getByRole("link", { name: /Saga #2/ }))
+			.toBeInTheDocument();
+		expect(mockedSearchDownloadedComics).toHaveBeenCalledWith("Saga");
+	});
+
+	test("shows an explicit online error when both remote sources fail", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.reject(new Error("offline"))),
+		);
+		const status = connectivity(false);
+		render(<SearchBar connectivity={status.source} />);
+		openSearch();
+		await page.getByRole("searchbox", { name: "Search series" }).fill("Saga");
+
+		await expect
+			.element(
+				page
+					.getByRole("alert")
+					.getByText("Online search is unavailable. Try again when connected."),
+			)
+			.toBeInTheDocument();
+	});
+});

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,6 +1,11 @@
 import { SEARCH_RESULT_LIMIT } from "@data/search.constants";
-import { computed, signal } from "@preact/signals";
-import { useEffect, useRef } from "preact/hooks";
+import {
+	createOfflineStatusSource,
+	type OfflineStatusSource,
+	searchDownloadedComics,
+} from "@lib/offline/search";
+import type { OfflineComicRecord } from "@lib/offline/types";
+import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 
 type LibraryResult = {
 	series_id: string;
@@ -18,87 +23,31 @@ type CVResult = {
 	cover_url?: string;
 };
 
-const query = signal("");
-const libraryResults = signal<LibraryResult[]>([]);
-const cvResults = signal<CVResult[]>([]);
-const loadingLibrary = signal(false);
-const loadingCV = signal(false);
-const loading = computed(() => loadingLibrary.value || loadingCV.value);
-const hasAnyResults = computed(
-	() => libraryResults.value.length > 0 || cvResults.value.length > 0,
-);
+type VisibleResult =
+	| ({ type: "library" } & LibraryResult)
+	| ({ type: "cv" } & CVResult)
+	| ({ type: "downloaded" } & OfflineComicRecord);
 
-// Flat list of visible results for keyboard navigation: library first, then CV.
-// activeIndex indexes into this list; cvOffset is where CV results start.
-const allResults = computed(() => [
-	...libraryResults.value
-		.slice(0, 5)
-		.map((r) => ({ type: "library" as const, ...r })),
-	...cvResults.value.slice(0, 5).map((r) => ({ type: "cv" as const, ...r })),
-]);
-const cvOffset = computed(() => libraryResults.value.slice(0, 5).length);
-const activeIndex = signal(-1);
+const RESULT_PREVIEW_LIMIT = 5;
+const SEARCH_DEBOUNCE_MS = 250;
 
-let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-
-function onQueryInput(e: Event) {
-	const val = (e.target as HTMLInputElement).value;
-	query.value = val;
-	activeIndex.value = -1;
-
-	if (debounceTimer) clearTimeout(debounceTimer);
-
-	if (!val.trim()) {
-		libraryResults.value = [];
-		cvResults.value = [];
-		loadingLibrary.value = false;
-		loadingCV.value = false;
-		return;
-	}
-
-	loadingLibrary.value = true;
-	loadingCV.value = true;
-
-	debounceTimer = setTimeout(() => {
-		const q = encodeURIComponent(val.trim());
-
-		fetch(`/api/search?q=${q}`)
-			.then((r) => (r.ok ? r.json() : []))
-			.then((data) => {
-				libraryResults.value = data;
-			})
-			.finally(() => {
-				loadingLibrary.value = false;
-			});
-
-		fetch(`/api/search/comicvine?q=${q}`)
-			.then((r) => (r.ok ? r.json() : []))
-			.then((data) => {
-				cvResults.value = data;
-			})
-			.finally(() => {
-				loadingCV.value = false;
-			});
-	}, 250);
+async function readSearchResponse<T>(
+	url: string,
+	signal: AbortSignal,
+): Promise<T[]> {
+	const response = await fetch(url, { signal });
+	if (!response.ok) throw new Error(`Search failed (${response.status})`);
+	return response.json() as Promise<T[]>;
 }
 
-function onKeyDown(e: KeyboardEvent) {
-	const len = allResults.value.length;
-	if (!len) return;
+function issueLabel(comic: OfflineComicRecord): string {
+	return `${comic.seriesName} #${comic.issueNumber}`;
+}
 
-	if (e.key === "ArrowDown") {
-		e.preventDefault();
-		activeIndex.value = Math.min(activeIndex.value + 1, len - 1);
-	} else if (e.key === "ArrowUp") {
-		e.preventDefault();
-		activeIndex.value = Math.max(activeIndex.value - 1, 0);
-	} else if (e.key === "Enter" && activeIndex.value >= 0) {
-		e.preventDefault();
-		const hit = allResults.value[activeIndex.value];
-		if (hit?.type === "library")
-			window.location.href = `/series/${hit.series_id}`;
-		if (hit?.type === "cv") window.location.href = `/series/${hit.id}`;
-	}
+function downloadedIssueMeta(comic: OfflineComicRecord): string {
+	return ["Downloaded", comic.issueName, comic.seriesYear]
+		.filter(Boolean)
+		.join(" · ");
 }
 
 function ResultItem({
@@ -126,7 +75,7 @@ function ResultItem({
 				{cover ? (
 					<img
 						src={cover}
-						alt=""
+						alt={`${name} cover`}
 						class="h-full w-full object-cover"
 						loading="lazy"
 					/>
@@ -191,22 +140,72 @@ function SectionLabel({
 	);
 }
 
-export function SearchBar() {
+export function SearchBar({
+	connectivity,
+}: {
+	/** Test seam for connectivity without changing browser globals. */
+	connectivity?: OfflineStatusSource;
+}) {
 	const dialogRef = useRef<HTMLDialogElement>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
+	const connectivityRef = useRef<OfflineStatusSource | null>(null);
+	connectivityRef.current ??= connectivity ?? createOfflineStatusSource();
+
+	const [query, setQuery] = useState("");
+	const [libraryResults, setLibraryResults] = useState<LibraryResult[]>([]);
+	const [cvResults, setCvResults] = useState<CVResult[]>([]);
+	const [downloadedResults, setDownloadedResults] = useState<
+		OfflineComicRecord[]
+	>([]);
+	const [loadingLibrary, setLoadingLibrary] = useState(false);
+	const [loadingCV, setLoadingCV] = useState(false);
+	const [loadingDownloaded, setLoadingDownloaded] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [offline, setOffline] = useState(
+		() => connectivityRef.current?.isOffline() ?? false,
+	);
+	const [activeIndex, setActiveIndex] = useState(-1);
+
+	const visibleResults = useMemo<VisibleResult[]>(
+		() =>
+			offline
+				? downloadedResults
+						.slice(0, RESULT_PREVIEW_LIMIT)
+						.map((result) => ({ type: "downloaded", ...result }))
+				: [
+						...libraryResults
+							.slice(0, RESULT_PREVIEW_LIMIT)
+							.map((result) => ({ type: "library" as const, ...result })),
+						...cvResults
+							.slice(0, RESULT_PREVIEW_LIMIT)
+							.map((result) => ({ type: "cv" as const, ...result })),
+					],
+		[cvResults, downloadedResults, libraryResults, offline],
+	);
+	const cvOffset = Math.min(libraryResults.length, RESULT_PREVIEW_LIMIT);
+	const loading = loadingLibrary || loadingCV || loadingDownloaded;
+	const hasAnyResults = visibleResults.length > 0;
+
+	useEffect(() => {
+		return connectivityRef.current?.subscribe((nextOffline) => {
+			setOffline(nextOffline);
+			setActiveIndex(-1);
+		});
+	}, []);
 
 	useEffect(() => {
 		function openDialog() {
-			const dialog = dialogRef.current;
-			if (!dialog) return;
-
-			query.value = "";
-			libraryResults.value = [];
-			cvResults.value = [];
-			loadingLibrary.value = false;
-			loadingCV.value = false;
-			activeIndex.value = -1;
-			dialog.showModal();
+			setQuery("");
+			setLibraryResults([]);
+			setCvResults([]);
+			setDownloadedResults([]);
+			setLoadingLibrary(false);
+			setLoadingCV(false);
+			setLoadingDownloaded(false);
+			setError(null);
+			setActiveIndex(-1);
+			setOffline(connectivityRef.current?.isOffline() ?? false);
+			dialogRef.current?.showModal();
 			requestAnimationFrame(() => inputRef.current?.focus());
 		}
 
@@ -215,12 +214,106 @@ export function SearchBar() {
 		return () => window.removeEventListener("open-search", openDialog);
 	}, []);
 
-	function onDialogClick(e: MouseEvent) {
-		if (e.target === dialogRef.current) dialogRef.current?.close();
+	useEffect(() => {
+		const trimmedQuery = query.trim();
+		setActiveIndex(-1);
+		setError(null);
+		if (!trimmedQuery) {
+			setLibraryResults([]);
+			setCvResults([]);
+			setDownloadedResults([]);
+			setLoadingLibrary(false);
+			setLoadingCV(false);
+			setLoadingDownloaded(false);
+			return;
+		}
+
+		const abortController = new AbortController();
+		let current = true;
+		const timer = window.setTimeout(async () => {
+			if (offline) {
+				setLibraryResults([]);
+				setCvResults([]);
+				setLoadingLibrary(false);
+				setLoadingCV(false);
+				setLoadingDownloaded(true);
+				try {
+					const results = await searchDownloadedComics(trimmedQuery);
+					if (current) setDownloadedResults(results);
+				} catch {
+					if (current) {
+						setDownloadedResults([]);
+						setError("Downloaded comics could not be searched.");
+					}
+				} finally {
+					if (current) setLoadingDownloaded(false);
+				}
+				return;
+			}
+
+			setDownloadedResults([]);
+			setLoadingDownloaded(false);
+			setLoadingLibrary(true);
+			setLoadingCV(true);
+			const encodedQuery = encodeURIComponent(trimmedQuery);
+			const [library, comicVine] = await Promise.allSettled([
+				readSearchResponse<LibraryResult>(
+					`/api/search?q=${encodedQuery}`,
+					abortController.signal,
+				),
+				readSearchResponse<CVResult>(
+					`/api/search/comicvine?q=${encodedQuery}`,
+					abortController.signal,
+				),
+			]);
+			if (!current) return;
+
+			setLibraryResults(library.status === "fulfilled" ? library.value : []);
+			setCvResults(comicVine.status === "fulfilled" ? comicVine.value : []);
+			setLoadingLibrary(false);
+			setLoadingCV(false);
+			if (library.status === "rejected" && comicVine.status === "rejected") {
+				setError("Online search is unavailable. Try again when connected.");
+			}
+		}, SEARCH_DEBOUNCE_MS);
+
+		return () => {
+			current = false;
+			window.clearTimeout(timer);
+			abortController.abort();
+		};
+	}, [offline, query]);
+
+	function onKeyDown(event: KeyboardEvent) {
+		if (visibleResults.length === 0) return;
+
+		if (event.key === "ArrowDown") {
+			event.preventDefault();
+			setActiveIndex((current) =>
+				Math.min(current + 1, visibleResults.length - 1),
+			);
+		} else if (event.key === "ArrowUp") {
+			event.preventDefault();
+			setActiveIndex((current) => Math.max(current - 1, 0));
+		} else if (event.key === "Enter" && activeIndex >= 0) {
+			event.preventDefault();
+			const hit = visibleResults[activeIndex];
+			if (hit?.type === "downloaded") {
+				window.location.href = `/comic/${encodeURIComponent(hit.issueId)}/read`;
+			} else if (hit?.type === "library") {
+				window.location.href = `/series/${hit.series_id}`;
+			} else if (hit?.type === "cv") {
+				window.location.href = `/series/${hit.id}`;
+			}
+		}
 	}
 
-	function onDialogKeyDown(e: KeyboardEvent) {
-		if (e.key === "Escape") dialogRef.current?.close();
+	function onDialogClick(event: MouseEvent) {
+		if (event.target === dialogRef.current) dialogRef.current?.close();
+	}
+
+	function onDialogKeyDown(event: KeyboardEvent) {
+		if (event.key === "Escape") dialogRef.current?.close();
 	}
 
 	return (
@@ -231,10 +324,9 @@ export function SearchBar() {
 			data-scroll="Dialog"
 			class="m-0 w-full max-w-none border-0 bg-transparent p-0 backdrop:bg-black/70 backdrop:backdrop-blur-sm"
 			style="top: 0; left: 0; height: 100dvh; max-height: 100dvh;"
-			aria-label="Search series"
+			aria-label={offline ? "Search downloaded comics" : "Search series"}
 		>
 			<div class="w-full border-b border-slate-700 bg-slate-900 shadow-2xl shadow-black/60 sm:mx-auto sm:mt-16 sm:max-w-xl sm:border">
-				{/* Input row */}
 				<div class="flex items-center border-b border-slate-800">
 					<span
 						aria-hidden="true"
@@ -242,7 +334,7 @@ export function SearchBar() {
 						style={{
 							mask: "url(/icons/search.svg) no-repeat center",
 							maskSize: "contain",
-							backgroundColor: loading.value ? "#f59e0b" : "#475569",
+							backgroundColor: loading ? "#f59e0b" : "#475569",
 							width: "16px",
 							height: "16px",
 							transition: "background-color 150ms",
@@ -253,11 +345,15 @@ export function SearchBar() {
 						type="search"
 						autoComplete="off"
 						spellcheck={false}
-						placeholder="Search series…"
-						aria-label="Search series"
+						placeholder={
+							offline ? "Search downloaded comics…" : "Search series…"
+						}
+						aria-label={offline ? "Search downloaded comics" : "Search series"}
 						aria-controls="search-listbox"
-						value={query.value}
-						onInput={onQueryInput}
+						value={query}
+						onInput={(event) =>
+							setQuery((event.target as HTMLInputElement).value)
+						}
 						onKeyDown={onKeyDown}
 						class="h-14 flex-1 bg-transparent text-base text-white placeholder-slate-500 outline-none sm:text-sm"
 					/>
@@ -273,99 +369,105 @@ export function SearchBar() {
 					</button>
 				</div>
 
-				{/* Results */}
-				{hasAnyResults.value && (
+				{offline && (
+					<p
+						role="status"
+						class="border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-amber-400"
+					>
+						Offline · Searching downloaded comics only
+					</p>
+				)}
+
+				{hasAnyResults && (
 					<ul id="search-listbox" aria-label="Search results">
-						{/* Library section */}
-						{libraryResults.value.length > 0 && (
+						{offline && downloadedResults.length > 0 && (
 							<>
 								<li>
-									<SectionLabel loading={loadingLibrary.value}>
+									<SectionLabel loading={loadingDownloaded}>
+										Downloaded comics
+									</SectionLabel>
+								</li>
+								{downloadedResults
+									.slice(0, RESULT_PREVIEW_LIMIT)
+									.map((comic, index) => (
+										<li key={comic.issueId}>
+											<ResultItem
+												cover={comic.coverCacheKey}
+												name={issueLabel(comic)}
+												meta={downloadedIssueMeta(comic)}
+												href={`/comic/${encodeURIComponent(comic.issueId)}/read`}
+												active={activeIndex === index}
+												onHover={() => setActiveIndex(index)}
+											/>
+										</li>
+									))}
+							</>
+						)}
+
+						{!offline && libraryResults.length > 0 && (
+							<>
+								<li>
+									<SectionLabel loading={loadingLibrary}>
 										In your library
 									</SectionLabel>
 								</li>
-								{libraryResults.value.slice(0, 5).map((r, i) => (
-									<li key={r.series_id}>
-										<ResultItem
-											cover={r.series_cover_url}
-											name={r.series_name}
-											meta={[r.series_year, r.series_publisher]
-												.filter(Boolean)
-												.join(" · ")}
-											href={`/series/${r.series_id}`}
-											active={activeIndex.value === i}
-											onHover={() => {
-												activeIndex.value = i;
-											}}
-										/>
-									</li>
-								))}
-								{libraryResults.value.length === SEARCH_RESULT_LIMIT && (
+								{libraryResults
+									.slice(0, RESULT_PREVIEW_LIMIT)
+									.map((result, index) => (
+										<li key={result.series_id}>
+											<ResultItem
+												cover={result.series_cover_url}
+												name={result.series_name}
+												meta={[result.series_year, result.series_publisher]
+													.filter(Boolean)
+													.join(" · ")}
+												href={`/series/${result.series_id}`}
+												active={activeIndex === index}
+												onHover={() => setActiveIndex(index)}
+											/>
+										</li>
+									))}
+								{libraryResults.length === SEARCH_RESULT_LIMIT && (
 									<li>
 										<a
-											href={`/search?q=${encodeURIComponent(query.value.trim())}`}
+											href={`/search?q=${encodeURIComponent(query.trim())}`}
 											class="flex items-center gap-1.5 border-t border-slate-800 px-4 py-2.5 text-xs font-bold uppercase tracking-widest text-amber-500 transition-colors hover:bg-slate-800/60"
 										>
 											See all library results
-											<div
-												aria-hidden="true"
-												style={{
-													mask: "url(/icons/arrow-forward.svg) no-repeat center",
-													maskSize: "contain",
-													backgroundColor: "currentColor",
-													width: "12px",
-													height: "12px",
-													flexShrink: 0,
-												}}
-											/>
 										</a>
 									</li>
 								)}
 							</>
 						)}
 
-						{/* ComicVine section */}
-						{cvResults.value.length > 0 && (
+						{!offline && cvResults.length > 0 && (
 							<>
 								<li>
-									<SectionLabel loading={loadingCV.value}>
-										ComicVine
-									</SectionLabel>
+									<SectionLabel loading={loadingCV}>ComicVine</SectionLabel>
 								</li>
-								{cvResults.value.slice(0, 5).map((r, i) => (
-									<li key={r.id}>
-										<ResultItem
-											cover={r.cover_url}
-											name={r.name}
-											meta={[r.start_year, r.publisher]
-												.filter(Boolean)
-												.join(" · ")}
-											href={`/series/${r.id}`}
-											active={activeIndex.value === cvOffset.value + i}
-											onHover={() => {
-												activeIndex.value = cvOffset.value + i;
-											}}
-										/>
-									</li>
-								))}
-								{cvResults.value.length === SEARCH_RESULT_LIMIT && (
+								{cvResults
+									.slice(0, RESULT_PREVIEW_LIMIT)
+									.map((result, index) => (
+										<li key={result.id}>
+											<ResultItem
+												cover={result.cover_url}
+												name={result.name}
+												meta={[result.start_year, result.publisher]
+													.filter(Boolean)
+													.join(" · ")}
+												href={`/series/${result.id}`}
+												active={activeIndex === cvOffset + index}
+												onHover={() => setActiveIndex(cvOffset + index)}
+											/>
+										</li>
+									))}
+								{cvResults.length === SEARCH_RESULT_LIMIT && (
 									<li>
 										<a
-											href={`/search?q=${encodeURIComponent(query.value.trim())}`}
+											href={`/search?q=${encodeURIComponent(query.trim())}`}
 											class="flex items-center gap-1.5 border-t border-slate-800 px-4 py-2.5 text-xs font-bold uppercase tracking-widest text-amber-500 transition-colors hover:bg-slate-800/60"
 										>
 											See all ComicVine results
-											<div
-												aria-hidden="true"
-												style={{
-													mask: "url(/icons/arrow-forward.svg) no-repeat center",
-													maskSize: "contain",
-													backgroundColor: "currentColor",
-													width: "12px",
-													height: "12px",
-													flexShrink: 0,
-												}}
-											/>
 										</a>
 									</li>
 								)}
@@ -374,15 +476,22 @@ export function SearchBar() {
 					</ul>
 				)}
 
-				{/* Loading state — before any results arrive */}
-				{query.value.trim() && loading.value && !hasAnyResults.value && (
-					<p class="px-4 py-4 text-xs text-slate-500">Searching…</p>
+				{query.trim() && loading && !hasAnyResults && (
+					<p role="status" class="px-4 py-4 text-xs text-slate-500">
+						Searching…
+					</p>
 				)}
 
-				{/* Empty state */}
-				{query.value.trim() && !loading.value && !hasAnyResults.value && (
-					<p class="px-4 py-4 text-xs text-slate-500">
-						No results for <span class="text-slate-300">"{query.value}"</span>
+				{error && (
+					<p role="alert" class="px-4 py-4 text-xs text-red-300">
+						{error}
+					</p>
+				)}
+
+				{query.trim() && !loading && !hasAnyResults && !error && (
+					<p role="status" class="px-4 py-4 text-xs text-slate-500">
+						{offline ? "No downloaded comics" : "No results"} for{" "}
+						<span class="text-slate-300">"{query}"</span>
 					</p>
 				)}
 			</div>

--- a/src/lib/offline/index.ts
+++ b/src/lib/offline/index.ts
@@ -2,4 +2,5 @@ export * from "./cache-names";
 export * from "./clear";
 export * from "./database";
 export * from "./outbox";
+export * from "./search";
 export * from "./types";

--- a/src/lib/offline/search.browser.test.ts
+++ b/src/lib/offline/search.browser.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test, vi } from "vitest";
+import { createOfflineStatusSource } from "./search";
+
+describe("createOfflineStatusSource", () => {
+	test("tracks browser and PWA lifecycle connectivity events", () => {
+		const events = new EventTarget();
+		const navigatorObject = { onLine: true };
+		const source = createOfflineStatusSource(navigatorObject, events);
+		const listener = vi.fn();
+		const unsubscribe = source.subscribe(listener);
+
+		expect(source.isOffline()).toBe(false);
+		events.dispatchEvent(
+			new CustomEvent("comics:pwa-status", {
+				detail: { status: "offline" },
+			}),
+		);
+		expect(source.isOffline()).toBe(true);
+		expect(listener).toHaveBeenLastCalledWith(true);
+
+		events.dispatchEvent(new Event("online"));
+		expect(source.isOffline()).toBe(false);
+		expect(listener).toHaveBeenLastCalledWith(false);
+
+		unsubscribe();
+		events.dispatchEvent(new Event("offline"));
+		expect(listener).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/lib/offline/search.test.ts
+++ b/src/lib/offline/search.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+import { filterDownloadedComics } from "./search";
+import type { OfflineComicRecord } from "./types";
+
+function comic(
+	issueId: string,
+	seriesName: string,
+	issueNumber: number | string,
+	overrides: Partial<OfflineComicRecord> = {},
+): OfflineComicRecord {
+	return {
+		issueId,
+		seriesId: `series-${seriesName}`,
+		seriesName,
+		issueNumber,
+		archiveCacheKey: `/api/comic/${issueId}/download`,
+		sizeBytes: 1024,
+		cachedAt: "2026-08-16T10:00:00.000Z",
+		updatedAt: "2026-08-16T10:00:00.000Z",
+		...overrides,
+	};
+}
+
+describe("filterDownloadedComics", () => {
+	test("matches every normalized term across downloaded metadata", () => {
+		const comics = [
+			comic("saga-10", "Saga", 10, {
+				issueName: "The War for Phang",
+				seriesPublisher: "Image",
+			}),
+			comic("saga-2", "Saga", 2, { issueName: "Waking Up" }),
+			comic("monstress-1", "Monstress", 1),
+		];
+
+		expect(
+			filterDownloadedComics(comics, "  SAGA   phang ").map(
+				({ issueId }) => issueId,
+			),
+		).toEqual(["saga-10"]);
+	});
+
+	test("matches issue metadata and uses natural issue ordering", () => {
+		const comics = [
+			comic("saga-10", "Saga", 10, { seriesYear: "2012" }),
+			comic("saga-2", "Saga", 2, { seriesYear: "2012" }),
+			comic("saga-special", "Saga", "2A", { seriesYear: "2012" }),
+		];
+
+		expect(
+			filterDownloadedComics(comics, "saga 2012").map(({ issueId }) => issueId),
+		).toEqual(["saga-2", "saga-special", "saga-10"]);
+	});
+
+	test("returns no issues for blank or unmatched searches", () => {
+		const comics = [comic("saga-1", "Saga", 1)];
+		expect(filterDownloadedComics(comics, "  ")).toEqual([]);
+		expect(filterDownloadedComics(comics, "Batman")).toEqual([]);
+	});
+});

--- a/src/lib/offline/search.ts
+++ b/src/lib/offline/search.ts
@@ -1,0 +1,119 @@
+import { offlineComics } from "./database";
+import type { OfflineComicRecord } from "./types";
+
+/** A browser connectivity source that can be replaced in component tests. */
+export type OfflineStatusSource = {
+	isOffline: () => boolean;
+	subscribe: (listener: (offline: boolean) => void) => () => void;
+};
+
+type NavigatorConnectivity = Pick<Navigator, "onLine">;
+
+type PwaStatusEventDetail = {
+	status?: "offline" | "preparing" | "ready" | "unavailable";
+};
+
+/**
+ * Creates a connectivity adapter from browser and PWA lifecycle events.
+ *
+ * `navigator.onLine` remains the fallback because the PWA client may not have
+ * emitted its first status event when this island hydrates.
+ */
+export function createOfflineStatusSource(
+	navigatorObject: NavigatorConnectivity = navigator,
+	eventTarget: EventTarget = window,
+): OfflineStatusSource {
+	let pwaOffline: boolean | null = null;
+
+	return {
+		isOffline: () => pwaOffline ?? navigatorObject.onLine === false,
+		subscribe: (listener) => {
+			const onOnline = () => {
+				pwaOffline = false;
+				listener(false);
+			};
+			const onOffline = () => {
+				pwaOffline = true;
+				listener(true);
+			};
+			const onPwaStatus = (event: Event) => {
+				const status = (event as CustomEvent<PwaStatusEventDetail>).detail
+					?.status;
+				if (!status) return;
+				pwaOffline = status === "offline";
+				listener(pwaOffline);
+			};
+
+			eventTarget.addEventListener("online", onOnline);
+			eventTarget.addEventListener("offline", onOffline);
+			eventTarget.addEventListener("comics:pwa-status", onPwaStatus);
+
+			return () => {
+				eventTarget.removeEventListener("online", onOnline);
+				eventTarget.removeEventListener("offline", onOffline);
+				eventTarget.removeEventListener("comics:pwa-status", onPwaStatus);
+			};
+		},
+	};
+}
+
+function searchableText(comic: OfflineComicRecord): string {
+	return [
+		comic.seriesName,
+		comic.seriesYear,
+		comic.seriesPublisher,
+		comic.issueNumber,
+		comic.issueName,
+		comic.issueDate,
+	]
+		.filter((value) => value != null)
+		.join(" ")
+		.toLocaleLowerCase();
+}
+
+function compareIssueNumbers(
+	left: OfflineComicRecord,
+	right: OfflineComicRecord,
+): number {
+	return String(left.issueNumber).localeCompare(
+		String(right.issueNumber),
+		undefined,
+		{ numeric: true, sensitivity: "base" },
+	);
+}
+
+/** Search and deterministically order downloaded issue metadata. */
+export function filterDownloadedComics(
+	comics: OfflineComicRecord[],
+	query: string,
+): OfflineComicRecord[] {
+	const terms = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+	if (terms.length === 0) return [];
+
+	return comics
+		.filter((comic) => {
+			const haystack = searchableText(comic);
+			return terms.every((term) => haystack.includes(term));
+		})
+		.sort((left, right) => {
+			const bySeries = left.seriesName.localeCompare(
+				right.seriesName,
+				undefined,
+				{
+					sensitivity: "base",
+				},
+			);
+			if (bySeries !== 0) return bySeries;
+			const byIssue = compareIssueNumbers(left, right);
+			return byIssue !== 0
+				? byIssue
+				: left.issueId.localeCompare(right.issueId);
+		});
+}
+
+/** Query only the local downloaded-comic metadata repository. */
+export async function searchDownloadedComics(
+	query: string,
+): Promise<OfflineComicRecord[]> {
+	return filterDownloadedComics(await offlineComics.getAll(), query);
+}


### PR DESCRIPTION
## Summary

- search downloaded issue and series metadata directly from IndexedDB while offline
- prevent offline searches from calling library or Comic Vine APIs
- label results and empty states as downloaded-only while preserving the online two-source search experience
- link cached results directly to their normal `/comic/{id}/read` routes
- preserve debounce cancellation, keyboard highlighting, loading, empty, and error states across connectivity changes

## Why

Once comics are stored locally, users need a dependable way to discover them without reaching an online API. This layer makes the existing header search connectivity-aware and limits offline results to bundles that are actually available on the device.

## Stack

- **4 of 9**
- Depends on #254
- Base: `codex/offline-comic-bundles`
- Next: `codex/offline-progress-sync`

## Validation

- `npm test` — 253 cumulative tests passed
- `npm run type:check:tsc`
