### PR TITLE
feat: sync reading progress by timestamp

### DIFF
--- a/src/lib/offline/index.ts
+++ b/src/lib/offline/index.ts
@@ -2,5 +2,6 @@ export * from "./cache-names";
 export * from "./clear";
 export * from "./database";
 export * from "./outbox";
+export * from "./progress-sync";
 export * from "./search";
 export * from "./types";

--- a/src/lib/offline/progress-sync.test.ts
+++ b/src/lib/offline/progress-sync.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test, vi } from "vitest";
+import type { OutboxRepository } from "./outbox";
+import {
+	createProgressReplayEngine,
+	createProgressReplayHandler,
+	saveReadingProgress,
+} from "./progress-sync";
+import type {
+	OfflineOutboxRecord,
+	OfflineProgressRecord,
+	ProgressOutboxRecord,
+} from "./types";
+
+const progress: OfflineProgressRecord = {
+	issueId: "issue/1",
+	currentPage: 12,
+	totalPages: 24,
+	updatedAt: "2026-08-16T12:34:56.000Z",
+	syncStatus: "pending",
+};
+
+const mutation: ProgressOutboxRecord = {
+	id: "mutation-1",
+	dedupeKey: "progress:issue/1",
+	kind: "progress",
+	payload: {
+		issueId: "issue/1",
+		currentPage: 12,
+		totalPages: 24,
+		updatedAt: "2026-08-16T12:34:56.000Z",
+		mutationId: "mutation-1",
+	},
+	createdAt: "2026-08-16T12:34:56.000Z",
+	updatedAt: "2026-08-16T12:34:56.000Z",
+	attempts: 0,
+	status: "pending",
+};
+
+class MemoryProgressRepository {
+	readonly records = new Map<string, OfflineProgressRecord>();
+
+	constructor(records: OfflineProgressRecord[] = []) {
+		for (const record of records) this.records.set(record.issueId, record);
+	}
+
+	async get(issueId: string): Promise<OfflineProgressRecord | undefined> {
+		return this.records.get(issueId);
+	}
+
+	async put(record: OfflineProgressRecord): Promise<void> {
+		this.records.set(record.issueId, record);
+	}
+}
+
+class MemoryOutboxRepository implements OutboxRepository {
+	readonly records = new Map<string, OfflineOutboxRecord>();
+
+	constructor(records: OfflineOutboxRecord[] = []) {
+		for (const record of records) this.records.set(record.id, record);
+	}
+
+	async getAll(): Promise<OfflineOutboxRecord[]> {
+		return [...this.records.values()];
+	}
+
+	async getByDedupeKey(
+		dedupeKey: string,
+	): Promise<OfflineOutboxRecord | undefined> {
+		return [...this.records.values()].find(
+			(record) => record.dedupeKey === dedupeKey,
+		);
+	}
+
+	async put(record: OfflineOutboxRecord): Promise<void> {
+		this.records.set(record.id, record);
+	}
+
+	async delete(id: string): Promise<void> {
+		this.records.delete(id);
+	}
+}
+
+describe("saveReadingProgress", () => {
+	test("atomically queues normalized local progress and its mutation", async () => {
+		const queueUpdate = vi.fn();
+
+		const result = await saveReadingProgress(
+			{
+				issueId: "issue-1",
+				currentPage: 8,
+				totalPages: 20,
+				updatedAt: "2026-08-16T13:34:56+01:00",
+				mutationId: "mutation-fixed",
+			},
+			{
+				getProgress: async () => undefined,
+				queueUpdate,
+			},
+		);
+
+		expect(result).toMatchObject({
+			queued: true,
+			progress: {
+				issueId: "issue-1",
+				currentPage: 8,
+				totalPages: 20,
+				updatedAt: "2026-08-16T12:34:56.000Z",
+				syncStatus: "pending",
+			},
+			mutation: {
+				id: "mutation-fixed",
+				dedupeKey: "progress:issue-1",
+				payload: {
+					totalPages: 20,
+					mutationId: "mutation-fixed",
+				},
+			},
+		});
+		expect(queueUpdate).toHaveBeenCalledWith(result.progress, result.mutation);
+	});
+
+	test("does not replace equal or newer local progress", async () => {
+		const queueUpdate = vi.fn();
+		const existing = { ...progress, updatedAt: "2026-08-16T13:00:00.000Z" };
+
+		await expect(
+			saveReadingProgress(
+				{
+					issueId: progress.issueId,
+					currentPage: 10,
+					totalPages: 24,
+					updatedAt: "2026-08-16T12:00:00.000Z",
+				},
+				{ getProgress: async () => existing, queueUpdate },
+			),
+		).resolves.toEqual({ queued: false, progress: existing });
+		expect(queueUpdate).not.toHaveBeenCalled();
+	});
+
+	test.each([
+		[{ issueId: "", currentPage: 1, totalPages: 1 }, "issueId"],
+		[{ issueId: "i", currentPage: 0, totalPages: 1 }, "currentPage"],
+		[{ issueId: "i", currentPage: 1, totalPages: 0 }, "totalPages"],
+		[{ issueId: "i", currentPage: 2, totalPages: 1 }, "cannot exceed"],
+	] as const)("rejects invalid local progress", async (input, message) => {
+		await expect(saveReadingProgress(input)).rejects.toThrow(message);
+	});
+});
+
+describe("createProgressReplayHandler", () => {
+	test("sends the timestamped API payload and marks matching progress synced", async () => {
+		const repository = new MemoryProgressRepository([progress]);
+		const fetcher = vi.fn(async () => new Response(null, { status: 200 }));
+		const handler = createProgressReplayHandler({
+			fetcher,
+			progressRepository: repository,
+		});
+
+		await handler(mutation);
+
+		expect(fetcher).toHaveBeenCalledWith(
+			"/api/comic/issue%2F1/progress",
+			expect.objectContaining({
+				method: "PATCH",
+				body: JSON.stringify({
+					current_page: 12,
+					total_pages: 24,
+					updated_at: progress.updatedAt,
+					mutation_id: mutation.id,
+				}),
+			}),
+		);
+		expect(repository.records.get(progress.issueId)?.syncStatus).toBe("synced");
+	});
+
+	test("marks permanent failures but leaves retryable failures pending", async () => {
+		const repository = new MemoryProgressRepository([progress]);
+		const permanentHandler = createProgressReplayHandler({
+			fetcher: async () =>
+				new Response(null, { status: 422, statusText: "Invalid page" }),
+			progressRepository: repository,
+		});
+		await permanentHandler(mutation);
+		expect(repository.records.get(progress.issueId)).toMatchObject({
+			syncStatus: "failed",
+			lastError: "HTTP 422: Invalid page",
+		});
+
+		await repository.put(progress);
+		const retryHandler = createProgressReplayHandler({
+			fetcher: async () => new Response(null, { status: 503 }),
+			progressRepository: repository,
+		});
+		await retryHandler(mutation);
+		expect(repository.records.get(progress.issueId)).toEqual(progress);
+	});
+
+	test("does not overwrite progress saved while a request was in flight", async () => {
+		const repository = new MemoryProgressRepository([
+			{ ...progress, updatedAt: "2026-08-16T13:00:00.000Z" },
+		]);
+		const handler = createProgressReplayHandler({
+			fetcher: async () => new Response(null, { status: 200 }),
+			progressRepository: repository,
+		});
+
+		await handler(mutation);
+
+		expect(repository.records.get(progress.issueId)?.syncStatus).toBe(
+			"pending",
+		);
+	});
+
+	test("replaces stale local progress with the authoritative server value", async () => {
+		const repository = new MemoryProgressRepository([progress]);
+		const handler = createProgressReplayHandler({
+			fetcher: async () =>
+				Response.json({
+					applied: false,
+					stale: true,
+					current_page: 19,
+					updated_at: "2026-08-16T13:00:00.000Z",
+				}),
+			progressRepository: repository,
+		});
+
+		await expect(handler(mutation)).resolves.toMatchObject({ status: 200 });
+		expect(repository.records.get(progress.issueId)).toEqual({
+			issueId: progress.issueId,
+			currentPage: 19,
+			totalPages: progress.totalPages,
+			updatedAt: "2026-08-16T13:00:00.000Z",
+			syncStatus: "synced",
+		});
+	});
+
+	test("retries a malformed stale response instead of discarding local progress", async () => {
+		const repository = new MemoryProgressRepository([progress]);
+		const handler = createProgressReplayHandler({
+			fetcher: async () => Response.json({ stale: true }),
+			progressRepository: repository,
+		});
+
+		await expect(handler(mutation)).resolves.toMatchObject({ status: 502 });
+		expect(repository.records.get(progress.issueId)).toEqual(progress);
+	});
+});
+
+describe("createProgressReplayEngine", () => {
+	test("uses generic retry policy for 5xx responses", async () => {
+		const outbox = new MemoryOutboxRepository([mutation]);
+		const progressRepository = new MemoryProgressRepository([progress]);
+		const engine = createProgressReplayEngine({
+			outboxRepository: outbox,
+			progressRepository,
+			fetcher: async () => new Response(null, { status: 503 }),
+			now: () => new Date("2026-08-16T14:00:00.000Z"),
+			retryDelayMs: () => 5_000,
+		});
+
+		await expect(engine.replay()).resolves.toMatchObject({
+			retryScheduled: 1,
+		});
+		expect(outbox.records.get(mutation.id)).toMatchObject({
+			attempts: 1,
+			nextAttemptAt: "2026-08-16T14:00:05.000Z",
+		});
+		expect(progressRepository.records.get(progress.issueId)?.syncStatus).toBe(
+			"pending",
+		);
+	});
+
+	test("purges and stops on an auth-invalid response", async () => {
+		const laterMutation: ProgressOutboxRecord = {
+			...mutation,
+			id: "mutation-2",
+			dedupeKey: "progress:issue-2",
+			payload: { ...mutation.payload, issueId: "issue-2" },
+			createdAt: "2026-08-16T13:00:00.000Z",
+			updatedAt: "2026-08-16T13:00:00.000Z",
+		};
+		const outbox = new MemoryOutboxRepository([mutation, laterMutation]);
+		const onAuthInvalid = vi.fn();
+		const fetcher = vi.fn(async () => new Response(null, { status: 401 }));
+		const engine = createProgressReplayEngine({
+			outboxRepository: outbox,
+			progressRepository: new MemoryProgressRepository([progress]),
+			fetcher,
+			onAuthInvalid,
+		});
+
+		await expect(engine.replay()).resolves.toMatchObject({
+			attempted: 1,
+			authInvalid: true,
+		});
+		expect(onAuthInvalid).toHaveBeenCalledOnce();
+		expect(fetcher).toHaveBeenCalledOnce();
+	});
+});

--- a/src/lib/offline/progress-sync.ts
+++ b/src/lib/offline/progress-sync.ts
@@ -1,0 +1,266 @@
+import { clearOfflineData } from "./clear";
+import {
+	offlineOutbox,
+	offlineProgress,
+	queueProgressUpdate,
+} from "./database";
+import {
+	createOutboxReplayEngine,
+	type OutboxReplayEngine,
+	type OutboxRepository,
+} from "./outbox";
+import type {
+	OfflineOutboxRecord,
+	OfflineProgressRecord,
+	ProgressOutboxRecord,
+} from "./types";
+
+export type SaveReadingProgressInput = {
+	issueId: string;
+	currentPage: number;
+	totalPages: number;
+	updatedAt?: string;
+	mutationId?: string;
+};
+
+export type SaveReadingProgressResult = {
+	queued: boolean;
+	progress: OfflineProgressRecord;
+	mutation?: ProgressOutboxRecord;
+};
+
+type ProgressRepository = {
+	get: (issueId: string) => Promise<OfflineProgressRecord | undefined>;
+	put: (record: OfflineProgressRecord) => Promise<void>;
+};
+
+export type SaveReadingProgressDependencies = {
+	getProgress?: ProgressRepository["get"];
+	queueUpdate?: typeof queueProgressUpdate;
+	now?: () => Date;
+	createMutationId?: () => string;
+};
+
+export type ProgressReplayHandlerOptions = {
+	fetcher?: typeof fetch;
+	progressRepository?: ProgressRepository;
+};
+
+export type ProgressReplayEngineOptions = ProgressReplayHandlerOptions & {
+	outboxRepository?: OutboxRepository;
+	onAuthInvalid?: () => void | Promise<void>;
+	now?: () => Date;
+	retryDelayMs?: (attempts: number) => number;
+};
+
+function normalizedTimestamp(
+	value: string | undefined,
+	now: () => Date,
+): string {
+	const date = value === undefined ? now() : new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		throw new Error("updatedAt must be a valid ISO timestamp");
+	}
+	return date.toISOString();
+}
+
+function defaultMutationId(): string {
+	return crypto.randomUUID();
+}
+
+function validateProgress(input: SaveReadingProgressInput): void {
+	if (!input.issueId.trim()) throw new Error("issueId is required");
+	if (!Number.isInteger(input.currentPage) || input.currentPage < 1) {
+		throw new Error("currentPage must be a positive integer");
+	}
+	if (!Number.isInteger(input.totalPages) || input.totalPages < 1) {
+		throw new Error("totalPages must be a positive integer");
+	}
+	if (input.currentPage > input.totalPages) {
+		throw new Error("currentPage cannot exceed totalPages");
+	}
+}
+
+/** Atomically saves local reading progress and its deduplicated outbox write. */
+export async function saveReadingProgress(
+	input: SaveReadingProgressInput,
+	dependencies: SaveReadingProgressDependencies = {},
+): Promise<SaveReadingProgressResult> {
+	validateProgress(input);
+	const now = dependencies.now ?? (() => new Date());
+	const updatedAt = normalizedTimestamp(input.updatedAt, now);
+	const getProgress = dependencies.getProgress ?? offlineProgress.get;
+	const existing = await getProgress(input.issueId);
+	if (existing && existing.updatedAt.localeCompare(updatedAt) >= 0) {
+		return { queued: false, progress: existing };
+	}
+
+	const mutationId =
+		input.mutationId ?? (dependencies.createMutationId ?? defaultMutationId)();
+	if (!mutationId.trim()) throw new Error("mutationId is required");
+
+	const progress: OfflineProgressRecord = {
+		issueId: input.issueId,
+		currentPage: input.currentPage,
+		totalPages: input.totalPages,
+		updatedAt,
+		syncStatus: "pending",
+	};
+	const mutation: ProgressOutboxRecord = {
+		id: mutationId,
+		dedupeKey: `progress:${input.issueId}`,
+		kind: "progress",
+		payload: {
+			issueId: input.issueId,
+			currentPage: input.currentPage,
+			totalPages: input.totalPages,
+			updatedAt,
+			mutationId,
+		},
+		createdAt: updatedAt,
+		updatedAt,
+		attempts: 0,
+		status: "pending",
+	};
+
+	await (dependencies.queueUpdate ?? queueProgressUpdate)(progress, mutation);
+	return { queued: true, progress, mutation };
+}
+
+async function updateProgressStatus(
+	record: ProgressOutboxRecord,
+	repository: ProgressRepository,
+	syncStatus: OfflineProgressRecord["syncStatus"],
+	lastError?: string,
+): Promise<void> {
+	const current = await repository.get(record.payload.issueId);
+	if (!current || current.updatedAt !== record.payload.updatedAt) return;
+	await repository.put({ ...current, syncStatus, lastError });
+}
+
+type ProgressSyncResponse = {
+	stale?: unknown;
+	current_page?: unknown;
+	updated_at?: unknown;
+};
+
+function isAuthoritativeProgress(
+	body: ProgressSyncResponse,
+): body is { stale: true; current_page: number; updated_at: string } {
+	return (
+		body.stale === true &&
+		typeof body.current_page === "number" &&
+		Number.isInteger(body.current_page) &&
+		body.current_page > 0 &&
+		typeof body.updated_at === "string" &&
+		!Number.isNaN(Date.parse(body.updated_at))
+	);
+}
+
+/** Creates the transport handler consumed by the generic outbox engine. */
+export function createProgressReplayHandler(
+	options: ProgressReplayHandlerOptions = {},
+): (record: ProgressOutboxRecord) => Promise<Response> {
+	const fetcher = options.fetcher ?? fetch;
+	const progressRepository = options.progressRepository ?? offlineProgress;
+
+	return async (record) => {
+		const response = await fetcher(
+			`/api/comic/${encodeURIComponent(record.payload.issueId)}/progress`,
+			{
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					current_page: record.payload.currentPage,
+					total_pages: record.payload.totalPages,
+					updated_at: record.payload.updatedAt,
+					mutation_id: record.payload.mutationId,
+				}),
+			},
+		);
+
+		if (response.ok) {
+			const body = (await response
+				.clone()
+				.json()
+				.catch(() => ({}))) as ProgressSyncResponse;
+			if (body.stale === true) {
+				if (!isAuthoritativeProgress(body)) {
+					return new Response(null, {
+						status: 502,
+						statusText: "Invalid stale progress response",
+					});
+				}
+				const current = await progressRepository.get(record.payload.issueId);
+				if (current?.updatedAt === record.payload.updatedAt) {
+					await progressRepository.put({
+						issueId: record.payload.issueId,
+						currentPage: body.current_page,
+						totalPages: record.payload.totalPages,
+						updatedAt: new Date(body.updated_at).toISOString(),
+						syncStatus: "synced",
+					});
+				}
+			} else {
+				await updateProgressStatus(record, progressRepository, "synced");
+			}
+		} else if (
+			response.status >= 400 &&
+			response.status < 500 &&
+			response.status !== 401 &&
+			response.status !== 403
+		) {
+			await updateProgressStatus(
+				record,
+				progressRepository,
+				"failed",
+				`HTTP ${response.status}${response.statusText ? `: ${response.statusText}` : ""}`,
+			);
+		}
+
+		return response;
+	};
+}
+
+function progressOnlyRepository(
+	repository: OutboxRepository,
+): OutboxRepository {
+	return {
+		getAll: async () =>
+			(await repository.getAll()).filter(
+				(record): record is ProgressOutboxRecord => record.kind === "progress",
+			),
+		getByDedupeKey: (dedupeKey) => repository.getByDedupeKey(dedupeKey),
+		put: (record) => repository.put(record),
+		delete: (id) => repository.delete(id),
+	};
+}
+
+/** Creates a progress-only replay engine for online launch/foreground events. */
+export function createProgressReplayEngine(
+	options: ProgressReplayEngineOptions = {},
+): OutboxReplayEngine {
+	const repository = progressOnlyRepository(
+		options.outboxRepository ?? offlineOutbox,
+	);
+	return createOutboxReplayEngine({
+		repository,
+		handlers: {
+			progress: createProgressReplayHandler(options),
+			"add-to-library": async () => ({ status: 500 }),
+		},
+		onAuthInvalid: async () => {
+			if (options.onAuthInvalid) await options.onAuthInvalid();
+			else await clearOfflineData();
+		},
+		now: options.now,
+		retryDelayMs: options.retryDelayMs,
+	});
+}
+
+/** Type guard for consumers observing generic outbox events. */
+export function isProgressMutation(
+	record: OfflineOutboxRecord,
+): record is ProgressOutboxRecord {
+	return record.kind === "progress";
+}


### PR DESCRIPTION
## Summary

- atomically persist one-based reading progress and its deduplicated outbox mutation
- attach a stable mutation id and normalized client timestamp to every queued update
- replay progress through the generic outbox engine with retry, permanent-failure, and auth-invalid handling
- reconcile stale device updates by replacing the matching older local position with the server's authoritative page and timestamp
- preserve any newer local progress written while an older request is in flight
- retry malformed conflict responses instead of silently discarding local state

## Why

Reading progress must survive offline sessions and multiple devices without an older device reversing newer server state. Timestamp ordering, stable mutation ids, and atomic local writes make foreground replay safe and idempotent.

## Stack

- **5 of 9**
- Depends on #255
- Base: `codex/offline-library-search`
- Next: `codex/offline-library-actions`

## Validation

- `npm test` — 266 cumulative tests passed
- `npm run type:check:tsc`
