### PR TITLE
feat: queue add-to-library actions offline

### DIFF
--- a/src/components/AddToLibrary/AddToLibrary.browser.test.tsx
+++ b/src/components/AddToLibrary/AddToLibrary.browser.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-preact";
+
+vi.mock("@lib/offline/library-sync", () => ({
+	OUTBOX_STATUS_EVENT: "comics:outbox-status",
+	getQueuedAddToLibrary: vi.fn(),
+	requestAddToLibrary: vi.fn(),
+}));
+
+const { getQueuedAddToLibrary, requestAddToLibrary } = await import(
+	"@lib/offline/library-sync"
+);
+const { AddToLibrary } = await import("./AddToLibrary");
+const mockedGetQueued = vi.mocked(getQueuedAddToLibrary);
+const mockedRequest = vi.mocked(requestAddToLibrary);
+
+beforeEach(() => {
+	mockedGetQueued.mockResolvedValue(undefined);
+	mockedRequest.mockResolvedValue({ status: "added" });
+});
+
+afterEach(() => vi.resetAllMocks());
+
+describe("AddToLibrary", () => {
+	test("shows online success after the optimistic request", async () => {
+		render(<AddToLibrary seriesId="series-1" />);
+
+		await page.getByRole("button", { name: "Add to library" }).click();
+		await expect
+			.element(page.getByRole("button", { name: "Added to library" }))
+			.toBeDisabled();
+		await expect
+			.element(page.getByText("Series added to your library."))
+			.toBeInTheDocument();
+		expect(mockedRequest).toHaveBeenCalledWith("series-1");
+	});
+
+	test("immediately exposes an obvious offline pending state", async () => {
+		vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+		let resolveRequest!: (value: { status: "pending" }) => void;
+		mockedRequest.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveRequest = resolve;
+				}),
+		);
+		render(<AddToLibrary seriesId="series-1" />);
+
+		await page.getByRole("button", { name: "Add to library" }).click();
+		await expect
+			.element(page.getByRole("button", { name: "Pending sync" }))
+			.toBeDisabled();
+		await expect
+			.element(page.getByText("Will add when you’re back online."))
+			.toBeInTheDocument();
+		resolveRequest({ status: "pending" });
+	});
+
+	test("restores a failed queued action and allows retry", async () => {
+		mockedGetQueued.mockResolvedValue({
+			id: "library-1",
+			dedupeKey: "library:series-1",
+			kind: "add-to-library",
+			payload: { seriesId: "series-1" },
+			createdAt: "2026-08-16T10:00:00.000Z",
+			updatedAt: "2026-08-16T10:00:00.000Z",
+			attempts: 1,
+			status: "failed",
+		});
+		render(<AddToLibrary seriesId="series-1" />);
+
+		await expect
+			.element(page.getByRole("button", { name: "Retry add" }))
+			.toBeEnabled();
+		await expect.element(page.getByRole("alert")).toBeInTheDocument();
+	});
+});

--- a/src/components/AddToLibrary/AddToLibrary.tsx
+++ b/src/components/AddToLibrary/AddToLibrary.tsx
@@ -1,24 +1,107 @@
-import { useCallback, useState } from "preact/hooks";
+import { Icon } from "@components/Icon/Icon";
+import {
+	getQueuedAddToLibrary,
+	OUTBOX_STATUS_EVENT,
+	requestAddToLibrary,
+} from "@lib/offline/library-sync";
+import { useCallback, useEffect, useId, useRef, useState } from "preact/hooks";
+
+type AddState = "idle" | "submitting" | "pending" | "added" | "failed";
+
+const LABELS: Record<AddState, string> = {
+	idle: "Add to library",
+	submitting: "Adding…",
+	pending: "Pending sync",
+	added: "Added to library",
+	failed: "Retry add",
+};
 
 export function AddToLibrary({ seriesId }: { seriesId: string }) {
-	const [buttonText, setButtonText] = useState("Add series to library");
-	const onClick = useCallback(async () => {
-		const res = await fetch(`/api/series/${seriesId}/add`, {
-			method: "PUT",
-		});
-		if (res.ok) {
-			setButtonText("Series added to library");
-		} else {
-			setButtonText("Failed to add series");
+	const [state, setState] = useState<AddState>("idle");
+	const [message, setMessage] = useState<string | null>(null);
+	const statusId = useId();
+	const hasQueuedAction = useRef(false);
+
+	const refreshQueuedState = useCallback(async () => {
+		try {
+			const queued = await getQueuedAddToLibrary(seriesId);
+			if (queued?.status === "failed") {
+				hasQueuedAction.current = true;
+				setState("failed");
+				setMessage("Couldn’t add this series. Try again.");
+			} else if (queued) {
+				hasQueuedAction.current = true;
+				setState("pending");
+				setMessage("Will add when you’re back online.");
+			} else if (hasQueuedAction.current) {
+				setState("added");
+				setMessage("Series added to your library.");
+			}
+		} catch {
+			// The click path surfaces storage failures; initial inspection is optional.
 		}
 	}, [seriesId]);
+
+	useEffect(() => {
+		void refreshQueuedState();
+		const onOutboxStatus = () => void refreshQueuedState();
+		window.addEventListener(OUTBOX_STATUS_EVENT, onOutboxStatus);
+		return () =>
+			window.removeEventListener(OUTBOX_STATUS_EVENT, onOutboxStatus);
+	}, [refreshQueuedState]);
+
+	const onClick = useCallback(async () => {
+		hasQueuedAction.current = true;
+		const offline = !navigator.onLine;
+		setState(offline ? "pending" : "submitting");
+		setMessage(
+			offline ? "Will add when you’re back online." : "Adding this series…",
+		);
+		try {
+			const result = await requestAddToLibrary(seriesId);
+			setState(result.status);
+			setMessage(
+				result.message ??
+					(result.status === "added"
+						? "Series added to your library."
+						: result.status === "pending"
+							? "Will add when you’re back online."
+							: "Couldn’t add this series. Try again."),
+			);
+		} catch {
+			setState("failed");
+			setMessage("Couldn’t save this action. Try again.");
+		}
+	}, [seriesId]);
+
+	const isDisabled =
+		state === "submitting" || state === "pending" || state === "added";
+
 	return (
-		<button
-			onClick={onClick}
-			type="button"
-			class="rounded-full bg-indigo-600 px-3.5 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-		>
-			{buttonText}
-		</button>
+		<div class="flex flex-wrap items-center gap-3">
+			<button
+				type="button"
+				onClick={onClick}
+				disabled={isDisabled}
+				aria-describedby={message ? statusId : undefined}
+				data-add-to-library-state={state}
+				class="group flex min-h-11 items-center gap-2 bg-amber-500 px-5 py-2.5 text-sm font-bold uppercase tracking-widest text-slate-950 transition-colors hover:bg-amber-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-300"
+			>
+				<Icon name={state === "added" ? "tick" : "add"} />
+				{LABELS[state]}
+			</button>
+			{message && (
+				<p
+					id={statusId}
+					role={state === "failed" ? "alert" : "status"}
+					aria-live="polite"
+					class={`text-xs font-bold uppercase tracking-widest ${
+						state === "failed" ? "text-red-400" : "text-amber-500"
+					}`}
+				>
+					{message}
+				</p>
+			)}
+		</div>
 	);
 }

--- a/src/lib/offline/library-sync.browser.test.ts
+++ b/src/lib/offline/library-sync.browser.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { renderPendingActionCountElements } from "./library-sync";
+
+describe("pending action count", () => {
+	test("renders pending and failed totals accessibly", () => {
+		const root = document.createElement("div");
+		root.innerHTML = "<span data-outbox-pending-count hidden></span>";
+
+		renderPendingActionCountElements({ pending: 2, failed: 1, total: 3 }, root);
+
+		const count = root.querySelector<HTMLElement>(
+			"[data-outbox-pending-count]",
+		);
+		expect(count?.hidden).toBe(false);
+		expect(count?.textContent).toBe("3");
+		expect(count?.dataset.state).toBe("failed");
+		expect(count?.getAttribute("aria-label")).toBe(
+			"2 pending actions, 1 failed actions",
+		);
+	});
+
+	test("hides when the outbox is empty", () => {
+		const root = document.createElement("div");
+		root.innerHTML = "<span data-outbox-pending-count>1</span>";
+		renderPendingActionCountElements({ pending: 0, failed: 0, total: 0 }, root);
+		expect(
+			root.querySelector<HTMLElement>("[data-outbox-pending-count]")?.hidden,
+		).toBe(true);
+	});
+});

--- a/src/lib/offline/library-sync.test.ts
+++ b/src/lib/offline/library-sync.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const records = vi.hoisted(() => new Map<string, unknown>());
+
+vi.mock("./database", () => ({
+	offlineOutbox: {
+		getAll: vi.fn(async () => [...records.values()]),
+		getByDedupeKey: vi.fn(async (dedupeKey: string) =>
+			[...records.values()].find(
+				(record) => (record as { dedupeKey?: string }).dedupeKey === dedupeKey,
+			),
+		),
+		put: vi.fn(async (record: { id: string; dedupeKey: string }) => {
+			for (const [id, existing] of records) {
+				if (
+					(existing as { dedupeKey?: string }).dedupeKey === record.dedupeKey &&
+					id !== record.id
+				) {
+					records.delete(id);
+				}
+			}
+			records.set(record.id, record);
+		}),
+		delete: vi.fn(async (id: string) => {
+			records.delete(id);
+		}),
+	},
+}));
+
+vi.mock("./clear", () => ({
+	clearOfflineData: vi.fn(async () => records.clear()),
+}));
+
+import {
+	getQueuedAddToLibrary,
+	queueAddToLibrary,
+	replayAddToLibrary,
+	requestAddToLibrary,
+} from "./library-sync";
+import { createOutboxReplayEngine } from "./outbox";
+
+beforeEach(() => {
+	records.clear();
+	vi.stubGlobal("navigator", { onLine: true });
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("add-to-library outbox", () => {
+	test("deduplicates a series while preserving its stable mutation id", async () => {
+		const first = await queueAddToLibrary(
+			"series-1",
+			new Date("2026-08-16T10:00:00.000Z"),
+		);
+		const second = await queueAddToLibrary(
+			"series-1",
+			new Date("2026-08-16T11:00:00.000Z"),
+		);
+
+		expect(records.size).toBe(1);
+		expect(second.id).toBe(first.id);
+		expect(second.dedupeKey).toBe("library:series-1");
+		expect(second.createdAt).toBe(first.createdAt);
+		expect(second.updatedAt).toBe("2026-08-16T11:00:00.000Z");
+	});
+
+	test("queues optimistically without making an offline request", async () => {
+		vi.stubGlobal("navigator", { onLine: false });
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+		await expect(requestAddToLibrary("series-1")).resolves.toEqual({
+			status: "pending",
+		});
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect((await getQueuedAddToLibrary("series-1"))?.status).toBe("pending");
+	});
+
+	test("posts JSON online and removes the mutation on success", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("{}", { status: 200 }));
+
+		await expect(requestAddToLibrary("series-1")).resolves.toEqual({
+			status: "added",
+		});
+		expect(records.size).toBe(0);
+		const init = fetchSpy.mock.calls[0]?.[1];
+		expect(init?.method).toBe("POST");
+		expect(JSON.parse(String(init?.body))).toMatchObject({
+			seriesId: "series-1",
+			mutationId: expect.stringContaining("library:series-1:"),
+		});
+	});
+
+	test.each([
+		[503, "pending"],
+		[422, "failed"],
+		[401, undefined],
+	] as const)("classifies HTTP %s without losing the action", async (status, queuedStatus) => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("{}", { status, statusText: `Status ${status}` }),
+		);
+
+		const result = await requestAddToLibrary("series-1");
+		expect(result.status).toBe(
+			status === 422 || status === 401 ? "failed" : "pending",
+		);
+		expect((await getQueuedAddToLibrary("series-1"))?.status).toBe(
+			queuedStatus,
+		);
+	});
+
+	test("retains an ambiguous network failure for replay", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("offline"));
+
+		await expect(requestAddToLibrary("series-1")).resolves.toEqual({
+			status: "pending",
+		});
+		expect(await getQueuedAddToLibrary("series-1")).toMatchObject({
+			status: "pending",
+			lastError: "offline",
+		});
+	});
+
+	test("normalises already-added conflicts for generic-engine replay", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ code: "already-added" }), {
+				status: 409,
+				statusText: "Conflict",
+			}),
+		);
+		const record = await queueAddToLibrary("series-1");
+		const engine = createOutboxReplayEngine({
+			handlers: {
+				progress: async () => ({ status: 204 }),
+				"add-to-library": replayAddToLibrary,
+			},
+			onAuthInvalid: vi.fn(),
+		});
+
+		await expect(engine.replay()).resolves.toMatchObject({ succeeded: 1 });
+		expect(records.size).toBe(0);
+		expect(record.id).toContain("library:series-1:");
+	});
+
+	test("lets the generic engine own auth invalidation", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("{}", { status: 403 }),
+		);
+		await queueAddToLibrary("series-1");
+		const onAuthInvalid = vi.fn();
+		const engine = createOutboxReplayEngine({
+			handlers: {
+				progress: async () => ({ status: 204 }),
+				"add-to-library": replayAddToLibrary,
+			},
+			onAuthInvalid,
+		});
+
+		await expect(engine.replay()).resolves.toMatchObject({ authInvalid: true });
+		expect(onAuthInvalid).toHaveBeenCalledOnce();
+		expect(records.size).toBe(1);
+	});
+});

--- a/src/lib/offline/library-sync.ts
+++ b/src/lib/offline/library-sync.ts
@@ -1,0 +1,227 @@
+import { clearOfflineData } from "./clear";
+import { offlineOutbox } from "./database";
+import {
+	getOutboxCounts,
+	type OutboxCounts,
+	type OutboxHandlerResult,
+	type OutboxReplayEngine,
+} from "./outbox";
+import type { AddToLibraryOutboxRecord } from "./types";
+
+export const OUTBOX_STATUS_EVENT = "comics:outbox-status";
+
+export type AddToLibraryRequestResult = {
+	status: "added" | "pending" | "failed";
+	message?: string;
+};
+
+function normaliseSeriesId(seriesId: string): string {
+	const normalised = seriesId.trim();
+	if (!normalised) throw new Error("Series id is required");
+	return normalised;
+}
+
+export function getLibraryDedupeKey(seriesId: string): string {
+	return `library:${normaliseSeriesId(seriesId)}`;
+}
+
+function createMutationId(seriesId: string): string {
+	return `library:${seriesId}:${crypto.randomUUID()}`;
+}
+
+export async function getQueuedAddToLibrary(
+	seriesId: string,
+): Promise<AddToLibraryOutboxRecord | undefined> {
+	const record = await offlineOutbox.getByDedupeKey(
+		getLibraryDedupeKey(seriesId),
+	);
+	return record?.kind === "add-to-library" ? record : undefined;
+}
+
+/** Queue one stable, deduplicated mutation for this series. */
+export async function queueAddToLibrary(
+	seriesId: string,
+	now = new Date(),
+): Promise<AddToLibraryOutboxRecord> {
+	const normalised = normaliseSeriesId(seriesId);
+	const dedupeKey = getLibraryDedupeKey(normalised);
+	const existing = await offlineOutbox.getByDedupeKey(dedupeKey);
+	const timestamp = now.toISOString();
+	const record: AddToLibraryOutboxRecord = {
+		id:
+			existing?.kind === "add-to-library"
+				? existing.id
+				: createMutationId(normalised),
+		dedupeKey,
+		kind: "add-to-library",
+		payload: { seriesId: normalised },
+		createdAt:
+			existing?.kind === "add-to-library" ? existing.createdAt : timestamp,
+		updatedAt: timestamp,
+		attempts: existing?.kind === "add-to-library" ? existing.attempts : 0,
+		status: "pending",
+	};
+	await offlineOutbox.put(record);
+	await publishOutboxStatus();
+	return record;
+}
+
+/** Transport handler composed into the shared OutboxReplayEngine. */
+export async function replayAddToLibrary(
+	record: AddToLibraryOutboxRecord,
+): Promise<OutboxHandlerResult> {
+	const response = await fetch("/api/library/add", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			seriesId: record.payload.seriesId,
+			mutationId: record.id,
+		}),
+	});
+
+	// Older servers may use 409 for an already-added series. It is equivalent
+	// to success for this idempotent resource mutation.
+	if (response.status === 409) {
+		const body = await response
+			.clone()
+			.json()
+			.catch(() => undefined);
+		if (
+			body &&
+			typeof body === "object" &&
+			"code" in body &&
+			(body as { code?: unknown }).code === "already-added"
+		) {
+			return { status: 200, statusText: "Already added" };
+		}
+	}
+
+	return { status: response.status, statusText: response.statusText };
+}
+
+async function deleteQueuedMutation(
+	record: AddToLibraryOutboxRecord,
+): Promise<void> {
+	const current = await offlineOutbox.getByDedupeKey(record.dedupeKey);
+	if (current?.id === record.id && current.updatedAt === record.updatedAt) {
+		await offlineOutbox.delete(record.id);
+	}
+}
+
+async function updateQueuedMutation(
+	record: AddToLibraryOutboxRecord,
+	update: Partial<AddToLibraryOutboxRecord>,
+): Promise<void> {
+	const current = await offlineOutbox.getByDedupeKey(record.dedupeKey);
+	if (current?.id !== record.id || current.updatedAt !== record.updatedAt)
+		return;
+	await offlineOutbox.put({ ...record, ...update });
+}
+
+/**
+ * Optimistically queues, then attempts the mutation immediately when online.
+ * Transient and ambiguous failures remain pending for shared-engine replay.
+ */
+export async function requestAddToLibrary(
+	seriesId: string,
+): Promise<AddToLibraryRequestResult> {
+	const record = await queueAddToLibrary(seriesId);
+	if (!navigator.onLine) return { status: "pending" };
+
+	try {
+		const response = await replayAddToLibrary(record);
+		if (response.status >= 200 && response.status < 300) {
+			await deleteQueuedMutation(record);
+			await publishOutboxStatus();
+			return { status: "added" };
+		}
+		if (response.status === 401 || response.status === 403) {
+			await clearOfflineData();
+			await publishOutboxStatus();
+			return { status: "failed", message: "Your session has expired." };
+		}
+		if (response.status >= 400 && response.status < 500) {
+			await updateQueuedMutation(record, {
+				attempts: record.attempts + 1,
+				status: "failed",
+				lastError: response.statusText || `HTTP ${response.status}`,
+			});
+			await publishOutboxStatus();
+			return { status: "failed" };
+		}
+		await updateQueuedMutation(record, {
+			lastError: response.statusText || `HTTP ${response.status}`,
+		});
+		await publishOutboxStatus();
+		return { status: "pending" };
+	} catch (error) {
+		await updateQueuedMutation(record, {
+			lastError:
+				error instanceof Error ? error.message : "Network request failed",
+		});
+		await publishOutboxStatus();
+		return { status: "pending" };
+	}
+}
+
+export function renderPendingActionCountElements(
+	counts: OutboxCounts,
+	root: ParentNode = document,
+): void {
+	for (const element of root.querySelectorAll<HTMLElement>(
+		"[data-outbox-pending-count]",
+	)) {
+		element.hidden = counts.total === 0;
+		element.dataset.state = counts.failed > 0 ? "failed" : "pending";
+		element.textContent = String(counts.total);
+		element.setAttribute(
+			"aria-label",
+			counts.failed > 0
+				? `${counts.pending} pending actions, ${counts.failed} failed actions`
+				: `${counts.pending} pending actions`,
+		);
+	}
+}
+
+export async function publishOutboxStatus(): Promise<OutboxCounts> {
+	const counts = await getOutboxCounts();
+	if (typeof window !== "undefined") {
+		window.dispatchEvent(
+			new CustomEvent<OutboxCounts>(OUTBOX_STATUS_EVENT, { detail: counts }),
+		);
+	}
+	return counts;
+}
+
+let pendingCountInitialised = false;
+
+/** Bind the header count once and refresh newly rendered header elements. */
+export function initialisePendingActionCount(): void {
+	if (typeof window === "undefined") return;
+	if (!pendingCountInitialised) {
+		window.addEventListener(OUTBOX_STATUS_EVENT, (event) => {
+			renderPendingActionCountElements(
+				(event as CustomEvent<OutboxCounts>).detail,
+			);
+		});
+		pendingCountInitialised = true;
+	}
+	void publishOutboxStatus().then((counts) =>
+		renderPendingActionCountElements(counts),
+	);
+}
+
+/** Connect shared-engine replay events to library and header presentation. */
+export function initialiseLibrarySync(
+	engine: Pick<OutboxReplayEngine, "subscribe" | "refreshCounts">,
+): () => void {
+	const unsubscribe = engine.subscribe(() => void publishOutboxStatus());
+	void engine.refreshCounts().then(({ counts }) => {
+		if (typeof window !== "undefined") {
+			window.dispatchEvent(
+				new CustomEvent<OutboxCounts>(OUTBOX_STATUS_EVENT, { detail: counts }),
+			);
+		}
+	});
+	return unsubscribe;
+}

--- a/src/pages/api/library/add.test.ts
+++ b/src/pages/api/library/add.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@data/mylar/mylar", () => ({ mylarAddSeries: vi.fn() }));
+
+import { mylarAddSeries } from "@data/mylar/mylar";
+import { POST, resetLibraryMutationLedgerForTesting } from "./add";
+
+const mockedMylarAddSeries = vi.mocked(mylarAddSeries);
+
+function request(body: unknown): Request {
+	return new Request("https://comics.example/api/library/add", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+async function post(body: unknown): Promise<Response> {
+	return POST({ request: request(body) } as never);
+}
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	resetLibraryMutationLedgerForTesting();
+	mockedMylarAddSeries.mockResolvedValue({
+		result: "success",
+		data: { comic: [], issues: [] },
+	});
+});
+
+describe("POST /api/library/add", () => {
+	test.each([
+		[{}, "seriesId"],
+		[{ seriesId: "" }, "seriesId"],
+		[{ seriesId: 123 }, "seriesId"],
+		[{ seriesId: "series-1", mutationId: "" }, "mutationId"],
+	])("validates JSON identifiers", async (body, field) => {
+		const response = await post(body);
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			error: expect.stringContaining(field),
+		});
+	});
+
+	test("adds a series using the consolidated JSON contract", async () => {
+		const response = await post({
+			seriesId: "series-1",
+			mutationId: "library:series-1:mutation-1",
+		});
+
+		expect(response.status).toBe(200);
+		expect(mockedMylarAddSeries).toHaveBeenCalledWith("series-1");
+		expect(await response.json()).toMatchObject({
+			status: "accepted",
+			seriesId: "series-1",
+			mutationId: "library:series-1:mutation-1",
+		});
+	});
+
+	test("does not repeat a completed mutation id", async () => {
+		const body = {
+			seriesId: "series-1",
+			mutationId: "library:series-1:mutation-1",
+		};
+		expect((await post(body)).status).toBe(200);
+		const replay = await post(body);
+
+		expect(replay.status).toBe(200);
+		expect(await replay.json()).toMatchObject({ status: "already-processed" });
+		expect(mockedMylarAddSeries).toHaveBeenCalledTimes(1);
+	});
+
+	test("treats Mylar already-added responses as success", async () => {
+		mockedMylarAddSeries.mockResolvedValue({
+			result: "error",
+			data: "Comic already exists",
+		} as never);
+
+		const response = await post({ seriesId: "series-2" });
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({ status: "already-added" });
+	});
+
+	test("returns a retryable upstream failure", async () => {
+		mockedMylarAddSeries.mockRejectedValue(new Error("unavailable"));
+
+		const response = await post({ seriesId: "series-3" });
+		expect(response.status).toBe(502);
+	});
+});

--- a/src/pages/api/library/add.ts
+++ b/src/pages/api/library/add.ts
@@ -1,30 +1,131 @@
 import { mylarAddSeries } from "@data/mylar/mylar";
 import type { APIRoute } from "astro";
 
-export const POST: APIRoute = async ({ request }) => {
-	const { seriesId } = await request.json();
+const completedMutations = new Set<string>();
+const inFlightMutations = new Map<string, Promise<unknown>>();
+const MAX_COMPLETED_MUTATIONS = 500;
 
-	if (!seriesId) {
-		return new Response(JSON.stringify({ error: "seriesId is required" }), {
-			status: 400,
-			headers: { "Content-Type": "application/json" },
-		});
+function json(body: unknown, status: number): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function isValidIdentifier(value: unknown, maxLength: number): value is string {
+	if (
+		typeof value !== "string" ||
+		value.trim().length === 0 ||
+		value.length > maxLength
+	) {
+		return false;
+	}
+	for (const character of value) {
+		const code = character.charCodeAt(0);
+		if (code <= 31 || code === 127) return false;
+	}
+	return true;
+}
+
+function isAlreadyAdded(value: unknown): boolean {
+	const description =
+		value instanceof Error
+			? value.message.toLowerCase()
+			: String(JSON.stringify(value) ?? "").toLowerCase();
+	return (
+		description.includes("already added") ||
+		description.includes("already exists") ||
+		description.includes("comic exists")
+	);
+}
+
+function isFailedMylarResult(value: unknown): boolean {
+	if (!value || typeof value !== "object" || !("result" in value)) return false;
+	const result = String((value as { result?: unknown }).result).toLowerCase();
+	return result === "error" || result === "failed" || result === "failure";
+}
+
+function rememberCompletedMutation(key: string): void {
+	completedMutations.add(key);
+	if (completedMutations.size <= MAX_COMPLETED_MUTATIONS) return;
+	const oldest = completedMutations.values().next().value;
+	if (oldest) completedMutations.delete(oldest);
+}
+
+/** Clears the process-local idempotency ledger between isolated unit tests. */
+export function resetLibraryMutationLedgerForTesting(): void {
+	completedMutations.clear();
+	inFlightMutations.clear();
+}
+
+export const POST: APIRoute = async ({ request }) => {
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: "Request body must be valid JSON" }, 400);
+	}
+	if (!body || typeof body !== "object" || Array.isArray(body)) {
+		return json({ error: "Request body must be an object" }, 400);
+	}
+	const { seriesId, mutationId } = body as {
+		seriesId?: unknown;
+		mutationId?: unknown;
+	};
+	if (!isValidIdentifier(seriesId, 128)) {
+		return json({ error: "seriesId must be a non-empty string" }, 400);
+	}
+	if (mutationId !== undefined && !isValidIdentifier(mutationId, 200)) {
+		return json({ error: "mutationId must be a non-empty string" }, 400);
 	}
 
-	try {
-		const result = await mylarAddSeries(String(seriesId));
-		return new Response(JSON.stringify(result), {
-			status: 200,
-			headers: { "Content-Type": "application/json" },
-		});
-	} catch (error) {
-		console.error("Failed to add series to library", error);
-		return new Response(
-			JSON.stringify({ error: "Failed to add series to library" }),
+	const normalisedSeriesId = seriesId.trim();
+	const idempotencyKey = mutationId ?? `series:${normalisedSeriesId}`;
+	if (completedMutations.has(idempotencyKey)) {
+		return json(
 			{
-				status: 502,
-				headers: { "Content-Type": "application/json" },
+				status: "already-processed",
+				seriesId: normalisedSeriesId,
+				mutationId: mutationId ?? null,
 			},
+			200,
 		);
+	}
+	try {
+		let operation = inFlightMutations.get(idempotencyKey);
+		if (!operation) {
+			operation = mylarAddSeries(normalisedSeriesId);
+			inFlightMutations.set(idempotencyKey, operation);
+		}
+		const result = await operation;
+		if (isFailedMylarResult(result) && !isAlreadyAdded(result)) {
+			throw new Error("Mylar rejected the add-series request");
+		}
+		rememberCompletedMutation(idempotencyKey);
+		return json(
+			{
+				status: isAlreadyAdded(result) ? "already-added" : "accepted",
+				seriesId: normalisedSeriesId,
+				mutationId: mutationId ?? null,
+				result,
+			},
+			200,
+		);
+	} catch (error) {
+		if (isAlreadyAdded(error)) {
+			rememberCompletedMutation(idempotencyKey);
+			return json(
+				{
+					status: "already-added",
+					seriesId: normalisedSeriesId,
+					mutationId: mutationId ?? null,
+				},
+				200,
+			);
+		}
+		console.error("Failed to add series to library", error);
+		return json({ error: "Failed to add series to library" }, 502);
+	} finally {
+		inFlightMutations.delete(idempotencyKey);
 	}
 };

--- a/src/pages/series/[id]/[...slug].astro
+++ b/src/pages/series/[id]/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import { Image } from "astro:assets";
+import { AddToLibrary } from "@components/AddToLibrary/AddToLibrary";
 import Breadcrumbs from "@components/Breadcrumbs.astro";
 import { BulkDownload } from "@components/ComicCache/BulkDownload";
 import type { ComicCacheMetadataInput } from "@components/ComicCache/comicCache.utils";
@@ -13,11 +14,7 @@ import {
 	getVolumeDetails,
 } from "@data/comicvine/comicvine";
 import type { ComicvineVolume } from "@data/comicvine/comicvine.types";
-import {
-	getDownloadedSeriesIssues,
-	getSeriesIssues,
-	getUnreadDownloadedSeriesIssues,
-} from "@data/elastic/queries";
+import { getSeriesCacheManifest, getSeriesIssues } from "@data/elastic/queries";
 import Layout from "@layouts/Layout.astro";
 
 const { id } = Astro.params;
@@ -58,7 +55,9 @@ if (!series) {
  * @returns Metadata shape consumed by the bulk cache island.
  */
 function toCacheMetadata(
-	issue: Awaited<ReturnType<typeof getDownloadedSeriesIssues>>[number],
+	issue: Awaited<
+		ReturnType<typeof getSeriesCacheManifest>
+	>["downloadedIssues"][number],
 ): ComicCacheMetadataInput {
 	return {
 		issueId: issue.issue_id,
@@ -70,18 +69,31 @@ function toCacheMetadata(
 		issueDate: issue.issue_date,
 		coverUrl: issue.issue_cover_url,
 		coverThumbHash: issue.issue_cover_thumb_hash,
+		previousIssue: issue.previousIssue
+			? {
+					issueId: issue.previousIssue.issue_id,
+					issueNumber: issue.previousIssue.issue_number,
+					issueName: issue.previousIssue.issue_name ?? undefined,
+				}
+			: null,
+		nextIssue: issue.nextIssue
+			? {
+					issueId: issue.nextIssue.issue_id,
+					issueNumber: issue.nextIssue.issue_number,
+					issueName: issue.nextIssue.issue_name ?? undefined,
+				}
+			: null,
 	};
 }
 
 let downloadedIssues: ComicCacheMetadataInput[] = [];
 let bulkDownloadIssues: ComicCacheMetadataInput[] = [];
 if (series) {
-	const [allDownloadedIssues, unreadDownloadedIssues] = await Promise.all([
-		getDownloadedSeriesIssues(id),
-		getUnreadDownloadedSeriesIssues(id),
-	]);
-	downloadedIssues = allDownloadedIssues.map(toCacheMetadata);
-	bulkDownloadIssues = unreadDownloadedIssues.map(toCacheMetadata);
+	const manifest = await getSeriesCacheManifest(id);
+	downloadedIssues = manifest.downloadedIssues.map(toCacheMetadata);
+	bulkDownloadIssues = downloadedIssues.filter((issue) =>
+		manifest.unreadDownloadedIssueIds.has(issue.issueId),
+	);
 }
 
 // Normalise to a common shape for the template
@@ -232,21 +244,7 @@ const cover2 = issues[1]?.issue_cover_url ?? null;
 				</div>
 
 				{cvVolume && (
-            <div class="flex items-center gap-3">
-              <button
-                type="button"
-                id="add-to-library-btn"
-                data-series-id={id}
-                class="group flex items-center gap-2 bg-amber-500 px-5 py-2.5 text-sm font-bold uppercase tracking-widest text-slate-900 transition-all hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <Icon name="add" class="h-4 w-4" color="currentColor" />
-                Add to library
-              </button>
-              <span
-                id="add-to-library-status"
-                class="hidden text-xs font-bold uppercase tracking-widest"
-              />
-            </div>
+					<AddToLibrary client:only="preact" seriesId={id} />
           )}
 
 				<div class="h-1 mt-2 w-full overflow-hidden bg-slate-800">
@@ -311,44 +309,3 @@ const cover2 = issues[1]?.issue_cover_url ?? null;
       <PageNavigator numberOfPages={cvTotalPages} currentPage={currentPage} />
     )}
 </Layout>
-
-<script>
-const btn = document.getElementById(
-	"add-to-library-btn",
-) as HTMLButtonElement | null;
-const status = document.getElementById("add-to-library-status");
-
-btn?.addEventListener("click", async () => {
-	const seriesId = btn.dataset.seriesId;
-	btn.disabled = true;
-	btn.textContent = "Adding…";
-
-	try {
-		const res = await fetch("/api/library/add", {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ seriesId }),
-		});
-
-		if (res.ok) {
-			btn.classList.add("hidden");
-			if (status) {
-				status.textContent = "Added to library";
-				status.classList.remove("hidden");
-				status.classList.add("text-amber-500");
-			}
-		} else {
-			btn.disabled = false;
-			btn.innerHTML = `<img src="/icons/add.svg" class="h-4 w-4" style="display:inline;filter:invert(1)" alt=""> Add to library`;
-			if (status) {
-				status.textContent = "Failed — try again";
-				status.classList.remove("hidden");
-				status.classList.add("text-red-400");
-			}
-		}
-	} catch {
-		btn.disabled = false;
-		btn.innerHTML = `<img src="/icons/add.svg" class="h-4 w-4" style="display:inline;filter:invert(1)" alt=""> Add to library`;
-	}
-});
-</script>


### PR DESCRIPTION
## Summary

- replace the series-page add control with an optimistic Preact action that queues before attempting the network request
- deduplicate queued actions per series while preserving one stable mutation id across retries
- classify offline/network/5xx outcomes as pending and permanent non-auth 4xx responses as failed
- purge all offline data immediately on an expired 401/403 session
- add a validated, idempotent `POST /api/library/add` contract with already-added normalization
- expose pending/failed counts and replay events for the PWA status UI added later in the stack

## Why

Users should be able to request a library addition while offline and trust that it will be replayed once connectivity returns. Queue-first optimistic state prevents ambiguous requests from being lost and keeps retries resource-idempotent.

## Stack

- **6 of 9**
- Depends on #256
- Base: `codex/offline-progress-sync`
- Next: `codex/offline-reader`

## Validation

- `npm test` — 288 cumulative tests passed
- `npm run type:check:tsc`
