### PR TITLE
feat: read downloaded comics on normal routes

### DIFF
--- a/src/components/ComicReader/ComicReader.browser.test.tsx
+++ b/src/components/ComicReader/ComicReader.browser.test.tsx
@@ -10,12 +10,24 @@ vi.mock("./comicReader.utils", () => ({
 	extractPages: vi.fn(),
 }));
 
+vi.mock("./offlineReader", () => ({
+	resolveReaderStartPage: vi.fn(),
+}));
+
+vi.mock("@lib/offline/progress-sync", () => ({
+	saveReadingProgress: vi.fn(),
+}));
+
 // Re-import after vi.mock so we get the mocked versions.
 const { downloadCbz, extractPages } = await import("./comicReader.utils");
+const { resolveReaderStartPage } = await import("./offlineReader");
+const { saveReadingProgress } = await import("@lib/offline/progress-sync");
 const { ComicReader } = await import("./ComicReader");
 
 const mockedDownloadCbz = vi.mocked(downloadCbz);
 const mockedExtractPages = vi.mocked(extractPages);
+const mockedResolveReaderStartPage = vi.mocked(resolveReaderStartPage);
+const mockedSaveReadingProgress = vi.mocked(saveReadingProgress);
 
 const ISSUE_ID = "abc";
 const PROGRESS_URL = `/api/comic/${ISSUE_ID}/progress`;
@@ -165,6 +177,39 @@ function triggerTabHidden() {
 beforeEach(() => {
 	// Default: sendBeacon succeeds. Individual tests can replace this spy.
 	vi.spyOn(navigator, "sendBeacon").mockReturnValue(true);
+	mockedResolveReaderStartPage.mockImplementation(
+		async (_issueId, pageNumber) => Math.max(1, pageNumber),
+	);
+	mockedSaveReadingProgress.mockImplementation(async (input) => {
+		const updatedAt = "2026-08-16T10:00:00.000Z";
+		const mutationId = `progress-${input.currentPage}`;
+		return {
+			queued: true,
+			progress: {
+				issueId: input.issueId,
+				currentPage: input.currentPage,
+				totalPages: input.totalPages,
+				updatedAt,
+				syncStatus: "pending",
+			},
+			mutation: {
+				id: mutationId,
+				dedupeKey: `progress:${input.issueId}`,
+				kind: "progress",
+				payload: {
+					issueId: input.issueId,
+					currentPage: input.currentPage,
+					totalPages: input.totalPages,
+					updatedAt,
+					mutationId,
+				},
+				createdAt: updatedAt,
+				updatedAt,
+				attempts: 0,
+				status: "pending",
+			},
+		};
+	});
 });
 
 afterEach(() => {
@@ -198,9 +243,36 @@ describe("ComicReader", () => {
 				.element(page.getByText("Download failed (500)"))
 				.toBeInTheDocument();
 		});
+
+		test("routes a corrupt offline archive back to saved comics", async () => {
+			mockedDownloadCbz.mockResolvedValue(new Uint8Array());
+			mockedExtractPages.mockRejectedValue(
+				new Error("Comic archive is corrupted or unreadable"),
+			);
+
+			render(
+				<ComicReader issueId={ISSUE_ID} initialPage={1} offlineMode={true} />,
+			);
+
+			await expect.element(page.getByRole("alert")).toBeInTheDocument();
+			await expect
+				.element(page.getByRole("link", { name: "Back to saved comics" }))
+				.toHaveAttribute("href", "/cache");
+		});
 	});
 
 	describe("rendering", () => {
+		test("restores locally saved progress when it is available", async () => {
+			setupHappyPath(3);
+			mockedResolveReaderStartPage.mockResolvedValue(2);
+
+			render(<ComicReader issueId={ISSUE_ID} initialPage={1} />);
+
+			await expect
+				.element(page.getByRole("img", { name: "Page 2" }))
+				.toBeInTheDocument();
+		});
+
 		test("renders the first page once the comic is ready", async () => {
 			setupHappyPath(3);
 
@@ -484,9 +556,43 @@ describe("ComicReader", () => {
 
 			expect(document.querySelector('a[href$="/read"]')).toBeNull();
 		});
+
+		test("shows the canonical gap message on the final page", async () => {
+			setupHappyPath(1);
+
+			render(
+				<ComicReader
+					issueId={ISSUE_ID}
+					initialPage={1}
+					hasUndownloadedNextIssue={true}
+				/>,
+			);
+
+			await expect
+				.element(page.getByText("Next issue isn’t downloaded"))
+				.toBeInTheDocument();
+		});
 	});
 
 	describe("progress saving", () => {
+		test("persists one-based local progress after page navigation", async () => {
+			setupHappyPath(3);
+
+			render(<ComicReader issueId={ISSUE_ID} initialPage={1} />);
+			await expect
+				.element(page.getByRole("img", { name: "Page 1" }))
+				.toBeInTheDocument();
+			await userEvent.keyboard("{ArrowRight}");
+
+			await vi.waitFor(() => {
+				expect(mockedSaveReadingProgress).toHaveBeenCalledWith({
+					issueId: ISSUE_ID,
+					currentPage: 2,
+					totalPages: 3,
+				});
+			});
+		});
+
 		test("flushes progress via sendBeacon when the tab is hidden", async () => {
 			setupHappyPath(3);
 			const beacon = vi.spyOn(navigator, "sendBeacon").mockReturnValue(true);
@@ -504,14 +610,21 @@ describe("ComicReader", () => {
 
 			triggerTabHidden();
 
-			expect(beacon).toHaveBeenCalledWith(PROGRESS_URL, expect.any(Blob));
+			await vi.waitFor(() => {
+				expect(beacon).toHaveBeenCalledWith(PROGRESS_URL, expect.any(Blob));
+			});
 			// Decode the body and assert the API contract.
 			const lastBeaconCall = beacon.mock.calls.at(-1);
 			if (!lastBeaconCall) throw new Error("Expected progress beacon call");
 			const [, blob] = lastBeaconCall;
 			if (!(blob instanceof Blob)) throw new Error("Expected beacon Blob body");
 			const body = JSON.parse(await blob.text());
-			expect(body).toEqual({ current_page: 2, total_pages: 3 });
+			expect(body).toEqual({
+				current_page: 2,
+				total_pages: 3,
+				updated_at: "2026-08-16T10:00:00.000Z",
+				mutation_id: "progress-2",
+			});
 		});
 
 		test("does not re-send progress for an unchanged page", async () => {
@@ -529,6 +642,7 @@ describe("ComicReader", () => {
 				.toBeInTheDocument();
 
 			triggerTabHidden();
+			await vi.waitFor(() => expect(beacon).toHaveBeenCalled());
 			const callsAfterFirstFlush = beacon.mock.calls.length;
 			expect(callsAfterFirstFlush).toBeGreaterThanOrEqual(1);
 

--- a/src/components/ComicReader/ComicReader.tsx
+++ b/src/components/ComicReader/ComicReader.tsx
@@ -1,4 +1,6 @@
 import { Icon } from "@components/Icon/Icon";
+import { saveReadingProgress } from "@lib/offline/progress-sync";
+import type { ProgressOutboxRecord } from "@lib/offline/types";
 import { useComputed, useSignal } from "@preact/signals";
 import type { TargetedMouseEvent, TargetedPointerEvent } from "preact";
 import { useEffect, useRef } from "preact/hooks";
@@ -23,6 +25,7 @@ import type {
 	ReaderZoomState,
 } from "./comicReader.types";
 import { downloadCbz, extractPages } from "./comicReader.utils";
+import { resolveReaderStartPage } from "./offlineReader";
 
 function defaultZoomState(): ReaderZoomState {
 	return { region: null, scale: 1, translateX: 0, translateY: 0 };
@@ -31,7 +34,10 @@ function defaultZoomState(): ReaderZoomState {
 export function ComicReader({
 	issueId,
 	initialPage,
+	initialProgressUpdatedAt,
 	nextIssue,
+	hasUndownloadedNextIssue = false,
+	offlineMode = false,
 	cacheMetadata,
 }: ComicReaderProps) {
 	const currentPage = useSignal(0);
@@ -63,6 +69,11 @@ export function ComicReader({
 	const imageRefs = useRef<(HTMLImageElement | null)[]>([]);
 
 	const lastSavedPageRef = useRef<number | null>(null);
+	const lastLocallySavedPageRef = useRef<number | null>(null);
+	const latestProgressMutationRef = useRef<ProgressOutboxRecord | null>(null);
+	const localSavePromiseRef = useRef<
+		Promise<ProgressOutboxRecord | undefined> | undefined
+	>();
 	const activeGestureRef = useRef<ActiveGesture | null>(null);
 	const lastTapRef = useRef<GesturePoint | null>(null);
 	const pendingTapTimeoutRef = useRef<number | null>(null);
@@ -70,10 +81,12 @@ export function ComicReader({
 	const suppressClickRef = useRef(false);
 	const suppressClickTimeoutRef = useRef<number | null>(null);
 
-	function buildProgressBody(): string {
+	function buildProgressBody(mutation: ProgressOutboxRecord): string {
 		return JSON.stringify({
-			current_page: currentPage.value + 1,
-			total_pages: pages.value.length,
+			current_page: mutation.payload.currentPage,
+			total_pages: mutation.payload.totalPages,
+			updated_at: mutation.payload.updatedAt,
+			mutation_id: mutation.payload.mutationId,
 		});
 	}
 
@@ -84,12 +97,52 @@ export function ComicReader({
 	 */
 	function flushProgress() {
 		if (pages.value.length === 0) return;
-		if (lastSavedPageRef.current === currentPage.value) return;
-		const ok = navigator.sendBeacon(
-			`/api/comic/${issueId}/progress`,
-			new Blob([buildProgressBody()], { type: "application/json" }),
-		);
-		if (ok) lastSavedPageRef.current = currentPage.value;
+		void persistLocalProgress().then((mutation) => {
+			if (!mutation || mutation.payload.currentPage !== currentPage.value + 1)
+				return;
+			if (lastSavedPageRef.current === currentPage.value) return;
+			if (!navigator.onLine) return;
+			const ok = navigator.sendBeacon(
+				`/api/comic/${issueId}/progress`,
+				new Blob([buildProgressBody(mutation)], { type: "application/json" }),
+			);
+			if (ok) lastSavedPageRef.current = currentPage.value;
+		});
+	}
+
+	function persistLocalProgress(): Promise<ProgressOutboxRecord | undefined> {
+		if (pages.value.length === 0) return Promise.resolve(undefined);
+		if (lastLocallySavedPageRef.current === currentPage.value) {
+			if (
+				latestProgressMutationRef.current?.payload.currentPage ===
+				currentPage.value + 1
+			) {
+				return Promise.resolve(latestProgressMutationRef.current);
+			}
+			return localSavePromiseRef.current ?? Promise.resolve(undefined);
+		}
+		const savingPage = currentPage.value;
+		lastLocallySavedPageRef.current = savingPage;
+		const saving = saveReadingProgress({
+			issueId,
+			currentPage: savingPage + 1,
+			totalPages: pages.value.length,
+		})
+			.then(({ mutation }) => {
+				if (mutation && currentPage.value === savingPage) {
+					latestProgressMutationRef.current = mutation;
+				}
+				return mutation;
+			})
+			.catch(() => {
+				// Reading remains usable when best-effort storage is unavailable.
+				if (lastLocallySavedPageRef.current === savingPage) {
+					lastLocallySavedPageRef.current = null;
+				}
+				return undefined;
+			});
+		localSavePromiseRef.current = saving;
+		return saving;
 	}
 
 	function clearPendingTap() {
@@ -288,19 +341,29 @@ export function ComicReader({
 	useEffect(() => {
 		supportsFullscreen.value = "requestFullscreen" in document.documentElement;
 		lastSavedPageRef.current = null;
+		lastLocallySavedPageRef.current = null;
+		latestProgressMutationRef.current = null;
+		localSavePromiseRef.current = undefined;
 
 		let cancelled = false;
 		let createdUrls: string[] = [];
 
 		(async () => {
 			try {
-				const cbz = await downloadCbz(
-					issueId,
-					(ratio) => {
-						downloadProgress.value = ratio;
-					},
-					cacheMetadata,
-				);
+				const [cbz, savedStartPage] = await Promise.all([
+					downloadCbz(
+						issueId,
+						(ratio) => {
+							downloadProgress.value = ratio;
+						},
+						cacheMetadata,
+					),
+					resolveReaderStartPage(
+						issueId,
+						initialPage,
+						initialProgressUpdatedAt,
+					),
+				]);
 				if (cancelled) return;
 
 				phase.value = "extracting";
@@ -320,7 +383,7 @@ export function ComicReader({
 				pages.value = urls;
 				const startPage = Math.max(
 					0,
-					Math.min((initialPage || 1) - 1, urls.length - 1),
+					Math.min(savedStartPage - 1, urls.length - 1),
 				);
 				currentPage.value = startPage;
 				phase.value = "ready";
@@ -338,7 +401,7 @@ export function ComicReader({
 			cancelled = true;
 			for (const url of createdUrls) URL.revokeObjectURL(url);
 		};
-	}, [issueId, initialPage, cacheMetadata]);
+	}, [issueId, initialPage, initialProgressUpdatedAt, cacheMetadata]);
 
 	useEffect(() => {
 		if (isLoading.value || pages.value.length === 0) return;
@@ -347,6 +410,10 @@ export function ComicReader({
 			measureImage();
 		});
 	}, [isLoading.value, pages.value.length]);
+
+	useEffect(() => {
+		if (!isLoading.value && pages.value.length > 0) persistLocalProgress();
+	}, [currentPage.value, isLoading.value, pages.value.length]);
 
 	useEffect(() => {
 		window.requestAnimationFrame(measureImage);
@@ -439,7 +506,7 @@ export function ComicReader({
 
 	function navigateBack() {
 		flushProgress();
-		window.location.href = `/comic/${issueId}`;
+		window.location.href = offlineMode ? "/cache" : `/comic/${issueId}`;
 	}
 
 	function toggleUI() {
@@ -592,10 +659,10 @@ export function ComicReader({
 			>
 				<p class="text-sm text-red-400">{error.value}</p>
 				<a
-					href={`/comic/${issueId}`}
+					href={offlineMode ? "/cache" : `/comic/${issueId}`}
 					class="text-sm font-semibold text-amber-500 hover:underline"
 				>
-					Back to issue
+					{offlineMode ? "Back to saved comics" : "Back to issue"}
 				</a>
 			</div>
 		);
@@ -796,6 +863,15 @@ export function ComicReader({
 						>
 							Read next
 						</a>
+					</div>
+				</div>
+			)}
+			{hasUndownloadedNextIssue && isLastPage.value && (
+				<div class="pointer-events-none absolute inset-x-0 bottom-0 z-30 bg-gradient-to-t from-black/90 via-black/70 to-transparent px-4 pb-5 pt-16">
+					<div class="mx-auto max-w-xl border-t border-slate-700 bg-black/80 px-4 py-4 text-center backdrop-blur-sm">
+						<p class="text-sm font-semibold text-white">
+							Next issue isn’t downloaded
+						</p>
 					</div>
 				</div>
 			)}

--- a/src/components/ComicReader/OfflineReaderShell.browser.test.tsx
+++ b/src/components/ComicReader/OfflineReaderShell.browser.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-preact";
+
+vi.mock("./offlineReader", () => ({
+	OFFLINE_READER_ERROR:
+		"This comic isn’t available offline or its saved copy is incomplete.",
+	loadOfflineReaderBootstrap: vi.fn(),
+}));
+
+vi.mock("./ComicReader", () => ({
+	ComicReader: ({ issueId }: { issueId: string }) => (
+		<p>Reader ready for {issueId}</p>
+	),
+}));
+
+const { loadOfflineReaderBootstrap } = await import("./offlineReader");
+const { OfflineReaderShell } = await import("./OfflineReaderShell");
+const mockedLoadBootstrap = vi.mocked(loadOfflineReaderBootstrap);
+
+afterEach(() => vi.resetAllMocks());
+
+describe("OfflineReaderShell", () => {
+	test("shows an accessible loading state while validating storage", async () => {
+		mockedLoadBootstrap.mockImplementation(() => new Promise(() => {}));
+		render(<OfflineReaderShell />);
+
+		await expect.element(page.getByRole("status")).toBeInTheDocument();
+		await expect
+			.element(page.getByText("Opening saved comic…"))
+			.toBeInTheDocument();
+	});
+
+	test("mounts the reader after the complete bundle is validated", async () => {
+		mockedLoadBootstrap.mockResolvedValue({
+			issueId: "abc",
+			initialPage: 3,
+			hasUndownloadedNextIssue: false,
+			offlineMode: true,
+		});
+		render(<OfflineReaderShell />);
+
+		await expect
+			.element(page.getByText("Reader ready for abc"))
+			.toBeInTheDocument();
+	});
+
+	test("routes missing and corrupt bundles back to the saved library", async () => {
+		mockedLoadBootstrap.mockRejectedValue(new Error("corrupt"));
+		render(<OfflineReaderShell />);
+
+		await expect.element(page.getByRole("alert")).toBeInTheDocument();
+		await expect
+			.element(page.getByRole("link", { name: "Back to saved comics" }))
+			.toHaveAttribute("href", "/cache");
+	});
+});

--- a/src/components/ComicReader/OfflineReaderShell.tsx
+++ b/src/components/ComicReader/OfflineReaderShell.tsx
@@ -1,0 +1,63 @@
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+import { ComicReader } from "./ComicReader";
+import type { OfflineReaderBootstrap } from "./offlineReader";
+import {
+	loadOfflineReaderBootstrap,
+	OFFLINE_READER_ERROR,
+} from "./offlineReader";
+
+export function OfflineReaderShell() {
+	const bootstrap = useSignal<OfflineReaderBootstrap | null>(null);
+	const error = useSignal<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		loadOfflineReaderBootstrap(window.location.pathname)
+			.then((result) => {
+				if (!cancelled) bootstrap.value = result;
+			})
+			.catch(() => {
+				if (!cancelled) error.value = OFFLINE_READER_ERROR;
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	if (error.value) {
+		return (
+			<main
+				class="flex h-dvh w-dvw flex-col items-center justify-center gap-5 bg-black px-6 text-center"
+				role="alert"
+			>
+				<div class="max-w-sm space-y-2">
+					<h1 class="text-lg font-bold text-white">Saved comic unavailable</h1>
+					<p class="text-sm leading-6 text-slate-400">{error.value}</p>
+				</div>
+				<a
+					href="/cache"
+					class="bg-amber-500 px-4 py-2 text-xs font-bold uppercase tracking-widest text-slate-950 transition-colors hover:bg-amber-400 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-amber-500"
+				>
+					Back to saved comics
+				</a>
+			</main>
+		);
+	}
+
+	if (!bootstrap.value) {
+		return (
+			<div
+				class="flex h-dvh w-dvw items-center justify-center bg-black"
+				role="status"
+				aria-live="polite"
+			>
+				<p class="text-sm font-bold uppercase tracking-widest text-slate-400">
+					Opening saved comic…
+				</p>
+			</div>
+		);
+	}
+
+	return <ComicReader {...bootstrap.value} />;
+}

--- a/src/components/ComicReader/comicReader.types.ts
+++ b/src/components/ComicReader/comicReader.types.ts
@@ -43,14 +43,19 @@ export type PanBounds = {
 export type NextIssueSummary = {
 	id: string;
 	seriesName: string;
-	issueNumber: number;
+	issueNumber: number | string;
 	issueName?: string;
 };
 
 export type ComicReaderProps = {
 	issueId: string;
 	initialPage: number;
+	initialProgressUpdatedAt?: string;
 	nextIssue?: NextIssueSummary;
+	/** True when canonical adjacency exists but that exact issue is not saved. */
+	hasUndownloadedNextIssue?: boolean;
+	/** Uses saved-library recovery links for fallback-shell errors. */
+	offlineMode?: boolean;
 	cacheMetadata?: ComicCacheMetadataInput;
 };
 

--- a/src/components/ComicReader/offlineReader.test.ts
+++ b/src/components/ComicReader/offlineReader.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@components/ComicCache/comicCache.utils", () => ({
+	getComicDownloadUrl: (issueId: string) =>
+		`/api/comic/${encodeURIComponent(issueId)}/download`,
+	openComicCache: vi.fn(),
+	readCachedComicMetadata: vi.fn(),
+}));
+
+vi.mock("@lib/offline/database", () => ({
+	offlineComics: { get: vi.fn() },
+	offlineProgress: { get: vi.fn(), put: vi.fn() },
+}));
+
+import {
+	openComicCache,
+	readCachedComicMetadata,
+} from "@components/ComicCache/comicCache.utils";
+import { offlineComics, offlineProgress } from "@lib/offline/database";
+import {
+	loadOfflineReaderBootstrap,
+	OFFLINE_READER_ERROR,
+	parseComicReaderIssueId,
+	resolveReaderStartPage,
+} from "./offlineReader";
+
+const cacheMatch = vi.fn();
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	vi.mocked(openComicCache).mockResolvedValue({ match: cacheMatch } as never);
+	vi.mocked(offlineProgress.get).mockResolvedValue(undefined);
+});
+
+describe("parseComicReaderIssueId", () => {
+	it.each([
+		["/comic/abc/read", "abc"],
+		["/comic/an%20issue/read/", "an issue"],
+		["/comic/abc", null],
+		["/offline/reader", null],
+		["/comic/%E0%A4%A/read", null],
+	])("parses %s", (pathname, expected) => {
+		expect(parseComicReaderIssueId(pathname)).toBe(expected);
+	});
+});
+
+describe("reader progress", () => {
+	it("prefers valid locally saved progress", async () => {
+		vi.mocked(offlineProgress.get).mockResolvedValue({
+			issueId: "abc",
+			currentPage: 7,
+			updatedAt: "2026-08-16T10:00:00.000Z",
+			syncStatus: "pending",
+		});
+		await expect(resolveReaderStartPage("abc", 3)).resolves.toBe(7);
+	});
+
+	it("falls back to a valid server page", async () => {
+		await expect(resolveReaderStartPage("abc", 3)).resolves.toBe(3);
+		await expect(resolveReaderStartPage("abc", 0)).resolves.toBe(1);
+	});
+
+	it("prefers newer server progress and uses server on equal timestamps", async () => {
+		vi.mocked(offlineProgress.get).mockResolvedValue({
+			issueId: "abc",
+			currentPage: 7,
+			updatedAt: "2026-08-16T10:00:00.000Z",
+			syncStatus: "synced",
+		});
+
+		await expect(
+			resolveReaderStartPage("abc", 9, "2026-08-16T11:00:00.000Z"),
+		).resolves.toBe(9);
+		await expect(
+			resolveReaderStartPage("abc", 8, "2026-08-16T10:00:00.000Z"),
+		).resolves.toBe(8);
+	});
+});
+
+describe("loadOfflineReaderBootstrap", () => {
+	const currentMetadata = {
+		version: 2 as const,
+		issueId: "abc",
+		seriesId: "series-1",
+		seriesName: "Sardine Squad",
+		issueNumber: 3,
+		previousIssue: null,
+		nextIssue: {
+			issueId: "next",
+			issueNumber: 4,
+			issueName: "The Briny Bit",
+		},
+		sizeBytes: 120,
+		cachedAt: "2026-08-16T09:00:00.000Z",
+		downloadUrl: "/api/comic/abc/download",
+		coverState: "unavailable" as const,
+	};
+	const currentRecord = {
+		issueId: "abc",
+		seriesId: "series-1",
+		seriesName: "Sardine Squad",
+		issueNumber: 3,
+		archiveCacheKey: "/api/comic/abc/download",
+		sizeBytes: 120,
+		cachedAt: currentMetadata.cachedAt,
+		updatedAt: currentMetadata.cachedAt,
+	};
+
+	it("loads a complete bundle and reports a canonical gap", async () => {
+		vi.mocked(readCachedComicMetadata).mockImplementation(async (id) =>
+			id === "abc" ? currentMetadata : null,
+		);
+		vi.mocked(offlineComics.get).mockImplementation(async (id) =>
+			id === "abc" ? currentRecord : undefined,
+		);
+		cacheMatch.mockImplementation(async (url: string) =>
+			url.includes("/abc/") ? new Response("archive") : undefined,
+		);
+
+		const result = await loadOfflineReaderBootstrap("/comic/abc/read");
+		expect(result).toMatchObject({
+			issueId: "abc",
+			initialPage: 1,
+			hasUndownloadedNextIssue: true,
+			offlineMode: true,
+		});
+		expect(result.nextIssue).toBeUndefined();
+	});
+
+	it("offers only the exact next issue when its complete bundle exists", async () => {
+		const nextMetadata = {
+			...currentMetadata,
+			issueId: "next",
+			issueNumber: 4,
+			nextIssue: null,
+			cachedAt: "2026-08-16T09:30:00.000Z",
+			downloadUrl: "/api/comic/next/download",
+		};
+		const nextRecord = {
+			...currentRecord,
+			issueId: "next",
+			issueNumber: 4,
+			archiveCacheKey: nextMetadata.downloadUrl,
+			cachedAt: nextMetadata.cachedAt,
+			updatedAt: nextMetadata.cachedAt,
+		};
+		vi.mocked(readCachedComicMetadata).mockImplementation(async (id) =>
+			id === "abc" ? currentMetadata : nextMetadata,
+		);
+		vi.mocked(offlineComics.get).mockImplementation(async (id) =>
+			id === "abc" ? currentRecord : nextRecord,
+		);
+		cacheMatch.mockResolvedValue(new Response("archive"));
+
+		const result = await loadOfflineReaderBootstrap("/comic/abc/read");
+		expect(result.hasUndownloadedNextIssue).toBe(false);
+		expect(result.nextIssue).toEqual({
+			id: "next",
+			seriesName: "Sardine Squad",
+			issueNumber: 4,
+			issueName: "The Briny Bit",
+		});
+	});
+
+	it("rejects a missing or inconsistent required bundle record", async () => {
+		vi.mocked(readCachedComicMetadata).mockResolvedValue(currentMetadata);
+		vi.mocked(offlineComics.get).mockResolvedValue(undefined);
+		cacheMatch.mockResolvedValue(new Response("archive"));
+
+		await expect(loadOfflineReaderBootstrap("/comic/abc/read")).rejects.toThrow(
+			OFFLINE_READER_ERROR,
+		);
+	});
+});

--- a/src/components/ComicReader/offlineReader.ts
+++ b/src/components/ComicReader/offlineReader.ts
@@ -1,0 +1,131 @@
+import {
+	getComicDownloadUrl,
+	openComicCache,
+	readCachedComicMetadata,
+} from "@components/ComicCache/comicCache.utils";
+import { offlineComics, offlineProgress } from "@lib/offline/database";
+import type { OfflineProgressRecord } from "@lib/offline/types";
+import type { ComicReaderProps, NextIssueSummary } from "./comicReader.types";
+
+export const OFFLINE_READER_ERROR =
+	"This comic isn’t available offline or its saved copy is incomplete.";
+
+export type OfflineReaderBootstrap = Pick<
+	ComicReaderProps,
+	"issueId" | "initialPage" | "cacheMetadata" | "offlineMode"
+> & {
+	nextIssue?: NextIssueSummary;
+	hasUndownloadedNextIssue: boolean;
+};
+
+/** Extracts an issue id without changing the normal reader URL. */
+export function parseComicReaderIssueId(pathname: string): string | null {
+	const match = pathname.match(/^\/comic\/([^/]+)\/read\/?$/);
+	if (!match) return null;
+	try {
+		const issueId = decodeURIComponent(match[1]);
+		return issueId.trim() ? issueId : null;
+	} catch {
+		return null;
+	}
+}
+
+function isUsableProgress(
+	record: OfflineProgressRecord | undefined,
+): record is OfflineProgressRecord {
+	return Boolean(
+		record &&
+			Number.isInteger(record.currentPage) &&
+			record.currentPage >= 1 &&
+			!Number.isNaN(Date.parse(record.updatedAt)),
+	);
+}
+
+/** Local progress wins when available because the server cannot be reached. */
+export async function resolveReaderStartPage(
+	issueId: string,
+	serverPage: number,
+	serverUpdatedAt?: string,
+): Promise<number> {
+	try {
+		const local = await offlineProgress.get(issueId);
+		if (isUsableProgress(local)) {
+			const serverTimestamp = serverUpdatedAt
+				? Date.parse(serverUpdatedAt)
+				: Number.NaN;
+			if (
+				Number.isNaN(serverTimestamp) ||
+				Date.parse(local.updatedAt) > serverTimestamp
+			) {
+				return local.currentPage;
+			}
+		}
+	} catch {
+		// IndexedDB may be unavailable or evicted; server progress remains usable.
+	}
+	return Number.isInteger(serverPage) && serverPage >= 1 ? serverPage : 1;
+}
+
+/**
+ * Validates and projects the complete v2 bundle needed by the generic shell.
+ * The archive is decoded by ComicReader after this lightweight presence check.
+ */
+export async function loadOfflineReaderBootstrap(
+	pathname: string,
+): Promise<OfflineReaderBootstrap> {
+	const issueId = parseComicReaderIssueId(pathname);
+	if (!issueId) throw new Error(OFFLINE_READER_ERROR);
+
+	const cache = await openComicCache();
+	if (!cache) throw new Error(OFFLINE_READER_ERROR);
+
+	const [metadata, record, archive, progress] = await Promise.all([
+		readCachedComicMetadata(issueId, cache),
+		offlineComics.get(issueId),
+		cache.match(getComicDownloadUrl(issueId)),
+		offlineProgress.get(issueId).catch(() => undefined),
+	]);
+
+	if (
+		!metadata ||
+		!record ||
+		!archive ||
+		record.archiveCacheKey !== metadata.downloadUrl ||
+		record.updatedAt !== metadata.cachedAt
+	) {
+		throw new Error(OFFLINE_READER_ERROR);
+	}
+
+	const nextReference = metadata.nextIssue;
+	let nextIssue: NextIssueSummary | undefined;
+	if (nextReference) {
+		const [nextRecord, nextArchive, nextMetadata] = await Promise.all([
+			offlineComics.get(nextReference.issueId),
+			cache.match(getComicDownloadUrl(nextReference.issueId)),
+			readCachedComicMetadata(nextReference.issueId, cache),
+		]);
+		if (
+			nextRecord &&
+			nextArchive &&
+			nextMetadata &&
+			nextRecord.archiveCacheKey === nextMetadata.downloadUrl &&
+			nextRecord.updatedAt === nextMetadata.cachedAt
+		) {
+			nextIssue = {
+				id: nextReference.issueId,
+				seriesName: nextRecord.seriesName || metadata.seriesName,
+				issueNumber: nextReference.issueNumber,
+				issueName: nextReference.issueName,
+			};
+		}
+	}
+
+	return {
+		issueId,
+		initialPage: isUsableProgress(progress) ? progress.currentPage : 1,
+		nextIssue,
+		hasUndownloadedNextIssue: Boolean(nextReference && !nextIssue),
+		offlineMode: true,
+		cacheMetadata: metadata,
+	};
+}

--- a/src/pages/comic/[id]/read.astro
+++ b/src/pages/comic/[id]/read.astro
@@ -1,7 +1,11 @@
 ---
 import type { ComicCacheMetadataInput } from "@components/ComicCache/comicCache.utils";
 import { ComicReader } from "@components/ComicReader/ComicReader";
-import { getIssue, getNextDownloadedIssue } from "@data/elastic/queries";
+import {
+	getAdjacentSeriesIssueReferences,
+	getIssue,
+	getNextDownloadedIssue,
+} from "@data/elastic/queries";
 import ReaderLayout from "@layouts/ReaderLayout.astro";
 
 const { id } = Astro.params;
@@ -14,7 +18,14 @@ if (!issue) return Astro.redirect("/series");
 if (issue.download_status !== "Downloaded")
 	return Astro.redirect(`/comic/${id}`);
 
-const nextIssue = await getNextDownloadedIssue(issue);
+const [nextIssue, adjacency] = await Promise.all([
+	getNextDownloadedIssue(issue),
+	getAdjacentSeriesIssueReferences(issue),
+]);
+// Never skip over an unavailable issue: the reader must preserve canonical
+// series order instead of presenting a later downloaded issue as "next".
+const exactNextIssue =
+	adjacency.nextIssue?.issue_id === nextIssue?.issue_id ? nextIssue : null;
 const cacheMetadata: ComicCacheMetadataInput = {
 	issueId: issue.issue_id,
 	seriesId: issue.series_id,
@@ -25,6 +36,20 @@ const cacheMetadata: ComicCacheMetadataInput = {
 	issueDate: issue.issue_date,
 	coverUrl: issue.issue_cover_url,
 	coverThumbHash: issue.issue_cover_thumb_hash,
+	previousIssue: adjacency.previousIssue
+		? {
+				issueId: adjacency.previousIssue.issue_id,
+				issueNumber: adjacency.previousIssue.issue_number,
+				issueName: adjacency.previousIssue.issue_name ?? undefined,
+			}
+		: null,
+	nextIssue: adjacency.nextIssue
+		? {
+				issueId: adjacency.nextIssue.issue_id,
+				issueNumber: adjacency.nextIssue.issue_number,
+				issueName: adjacency.nextIssue.issue_name ?? undefined,
+			}
+		: null,
 };
 ---
 
@@ -33,15 +58,17 @@ const cacheMetadata: ComicCacheMetadataInput = {
 		client:only="preact"
 		issueId={id}
 		initialPage={issue.current_page ?? 0}
-		nextIssue={nextIssue
+		initialProgressUpdatedAt={issue.progress_updated_at}
+		nextIssue={exactNextIssue
       ? {
-          id: nextIssue.issue_id,
+          id: exactNextIssue.issue_id,
           seriesName:
-            nextIssue.series_name ?? issue.series_name ?? "Next issue",
-          issueNumber: nextIssue.issue_number,
-          issueName: nextIssue.issue_name ?? undefined,
+            exactNextIssue.series_name ?? issue.series_name ?? "Next issue",
+          issueNumber: exactNextIssue.issue_number,
+          issueName: exactNextIssue.issue_name ?? undefined,
         }
       : undefined}
+		hasUndownloadedNextIssue={Boolean(adjacency.nextIssue && !exactNextIssue)}
 		cacheMetadata={cacheMetadata}
 	/>
 </ReaderLayout>

--- a/src/pages/offline/reader.astro
+++ b/src/pages/offline/reader.astro
@@ -1,0 +1,8 @@
+---
+import { OfflineReaderShell } from "@components/ComicReader/OfflineReaderShell";
+import ReaderLayout from "@layouts/ReaderLayout.astro";
+---
+
+<ReaderLayout title="Read saved comic">
+	<OfflineReaderShell client:only="preact" />
+</ReaderLayout>


### PR DESCRIPTION
## Summary

- add a prerendered generic reader shell that can bootstrap a saved issue from the normal `/comic/{id}/read` URL
- require a complete v2 metadata sidecar, IndexedDB projection, and CBZ archive before mounting the reader
- restore the newest valid local/server progress value, with the server winning timestamp ties
- save reader progress atomically and reuse the exact queued timestamp/mutation-id pair for beacon delivery
- use server-derived previous/next references and open only the exact adjacent downloaded issue
- show **Next issue isn’t downloaded** for a deliberate gap instead of skipping ahead
- provide a clear unavailable-copy error and route back to cached comics

## Why

Downloaded archives are only useful offline if the existing reader can be reached without a server-rendered issue page. This shell preserves normal URLs, validates local completeness, restores progress, and retains canonical series order.

## Stack

- **7 of 9**
- Depends on #257
- Base: `codex/offline-library-actions`
- Next: `codex/offline-pwa-shell`

## Validation

- `npm test` — 306 cumulative tests passed
- `npm run type:check:tsc`
