### PR TITLE
test: harden offline PWA releases for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comics
 
-An Astro server-side rendered (SSR) application for browsing and managing a personal comics library. Features a clean UI built with Astro components and Preact islands for interactivity, styled using Tailwind CSS.
+An Astro server-side rendered (SSR) application for browsing, downloading, and reading a personal comics library. It is an installable iOS PWA with an offline app shell, locally saved comics, and a UI built with Astro components, Preact islands, and Tailwind CSS.
 
 ## Overview
 
@@ -9,14 +9,16 @@ This app helps you:
 - Track series and issues from Mylar
 - View weekly new releases from Comic Vine
 - Manage cover images locally
+- Install the app on iOS and navigate saved pages while offline
+- Download comics for offline reading
 
 ## Tech Stack
 
-- **Framework**: Astro 5 SSR with Node adapter
+- **Framework**: Astro 7 SSR with Node adapter
 - **UI**: Astro components + Preact islands for interactivity
 - **Styling**: Tailwind CSS 4
 - **State**: Nanostores for client-side state management
-- **Testing**: Vitest
+- **Testing**: Vitest with Playwright-backed Chromium and opt-in WebKit coverage
 - **Language**: TypeScript
 
 ## Commands
@@ -30,7 +32,26 @@ All commands are run from the root of the project:
 | `npm run build`      | Build production site to `./dist/`          |
 | `npm run preview`    | Preview build locally before deploying      |
 | `npm run type:check` | Run Astro type checking                     |
-| `npx vitest run`     | Run tests                                   |
+| `npm run type:check:tsc` | Run TypeScript checking               |
+| `npm run lint`       | Run Biome checks                            |
+| `npm test`           | Run unit and browser tests                  |
+
+## PWA release checks
+
+Routine `npm test` uses Chromium so a missing optional WebKit binary does not
+break local development. Before an iOS PWA release, run the WebKit and built-
+artifact gates as well:
+
+```bash
+npx playwright install webkit
+PWA_WEBKIT=1 npx vitest run --project browser
+npm run build
+PWA_BUILD_SMOKE=1 npx vitest run --project node tests/pwa-build-smoke.test.ts
+```
+
+WebKit automation covers browser API compatibility, but installation,
+force-close behavior, storage eviction, and service-worker promotion still need
+the [real-iPhone checklist](docs/TESTING.md#real-iphone-release-checklist).
 
 ## Project Structure
 
@@ -63,10 +84,11 @@ Detailed documentation is available in the `docs/` folder:
 - [Cover Images](docs/COVER_IMAGES.md) - Cover caching and serving
 - [Testing](docs/TESTING.md) - Testing approach
 - [Hosting](docs/HOSTING.md) - Deployment and infrastructure
+- [Offline mode](docs/OFFLINE.md) - PWA, local storage, and cache policy
 
 ## Requirements
 
-- Node.js 22.12.0 (see `.nvmrc`)
+- Node.js 24.18.0 (see `.nvmrc`)
 - Elasticsearch instance
 - Mylar instance
 - Comic Vine API key

--- a/docs/COVER_IMAGES.md
+++ b/docs/COVER_IMAGES.md
@@ -1,10 +1,11 @@
 # Cover images
 
-Cover images use a hybrid approach based on whether an issue has been downloaded:
+Cover images use a hybrid approach based on whether an issue has been downloaded.
 
-### Downloaded issues (extracted from CBZ)
+## Downloaded issues (extracted from CBZ)
 
 For issues with `status: "Downloaded"`:
+
 1. The first image file in the CBZ archive (alphabetically sorted by filename) is treated as the cover.
 2. That image is extracted from the CBZ via Mylar's `downloadIssue` API and cached under `COVERS_DIR` using a stable filename (e.g. `{issueId}.jpg`).
 3. Elasticsearch stores this cover filename (relative path like `{issueId}.jpg`) in the normalized `Issue` document (not the original CBZ location).
@@ -12,23 +13,39 @@ For issues with `status: "Downloaded"`:
 5. UI components build cover `src` URLs pointing at `/covers/...` when an issue is marked as downloaded.
 6. Astro's `<Image>` component handles resizing and format conversion on-demand.
 
-### Non-downloaded issues (ComicVine direct)
+## Browser offline bundles
+
+Downloading an issue into the browser also makes a best-effort request for its
+cover and stores the response bytes in the `comic-reader-v2` Cache Storage
+bundle's companion `comics-offline-covers-v1` bucket. Bundle metadata retains the
+original cover URL as the source and a same-origin
+`/offline/comics/{issueId}/cover` cache key, plus a ThumbHash for placeholder
+rendering.
+
+The CBZ archive and validated issue/series metadata are required. A cover is not:
+if its request or cache write fails, the comic remains readable and its metadata
+is marked `pending`. A later bundle access retries the cover. Deleting the comic
+bundle removes the archive, metadata sidecar, searchable IndexedDB record, and
+cached cover response.
+
+## Non-downloaded issues (ComicVine direct)
+
 For issues with `status: "Wanted"` or `"Skipped"`:
+
 1. Elasticsearch stores the original ComicVine URL.
 2. Browser fetches directly from ComicVine (CDN allows browser requests).
 3. No server-side caching (since we can't reliably fetch from ComicVine server-side).
 
-### Configuration
+## Configuration
 
 - `COVERS_DIR`: Local directory for cached covers (default: `data/covers`)
 
-```
+## Implementation
 
-### Implementation
-
-- `src/util/covers.ts`: CBZ extraction and caching logiciesArt`)
+- `src/util/covers.ts`: server-side CBZ cover extraction and caching
 - `src/pages/covers/[...path].ts`: Route handler for serving covers
+- `src/components/ComicCache/comicCache.utils.ts`: browser bundle and cover caching
 
-### Dependencies
+## Dependencies
 
 - `fflate`: Used for CBZ extraction (CBZ files are ZIP archives)

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -14,7 +14,7 @@ Each data source has a dedicated module in `src/data/` that exposes multiple fun
 
 Shared shapes live next to the clients:
 
-- `src/util/comics.types.ts`: normalized `Issue` shape used throughout the app
+- `src/data/comics.types.ts`: normalized `Issue` shape used throughout the app
 - `src/data/mylar/mylar.types.ts`, `src/data/comicvine/comicvine.types.ts`: upstream response typings
 
 ## Upstream sources
@@ -88,9 +88,34 @@ Shared shapes live next to the clients:
 
 - `src/data/elastic/elastic.ts`
 
+### Offline bundle metadata
+
+The series page asks Elasticsearch for the complete server-sorted issue list
+when it prepares downloadable browser bundles. Downloaded issues receive
+references to their immediate previous and next entries in that result—even if
+an adjacent issue has not been downloaded. This preserves canonical series
+ordering and lets the offline reader report a real download gap instead of
+silently skipping it.
+
+The browser metadata sidecar contains stable issue and series identifiers,
+display names, issue number/date, cover information, adjacency references,
+archive size, and cache timestamp. The matching IndexedDB record is the
+searchable projection used by offline library and search views. Both are local
+projections of Elasticsearch data, not additional server-side sources of truth.
+
+### Reading progress conflict resolution
+
+Elasticsearch stores `current_page`, `progress_updated_at`, and the last applied
+`progress_mutation_id` on each issue. The progress API requires the client to
+send `current_page`, `total_pages`, an ISO `updated_at`, and a mutation id. Its
+scripted update applies only timestamps strictly newer than the stored value;
+equal or older timestamps return a successful stale result without changing the
+document. Reading-state transition timestamps use that same client timestamp so
+the page and its derived `reading`/`read` state remain one atomic update.
+
 > Note: `src/env.d.ts` declares `ELASTIC_URL` and `ELASTIC_INDEX`, but the current implementation uses hard-coded values. The `ELASTIC_URL` is hard-coded in `src/data/elastic/elastic.ts` and the index name is defined in `src/data/elastic/models/issue.model.ts`. If you want these to be runtime-configurable, wire them through `import.meta.env`.
 
 
 ## Keeping this doc accurate over time
 
-When code moves, the most reliable way to re-ground this document is to start from `src/data/` (clients) and `src/util/` (utilities) and follow imports.
+When code moves, the most reliable way to re-ground this document is to start from `src/data/` and follow imports.

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -61,3 +61,69 @@ Typical lifecycle:
 ## CDN
 
 The webapp uses Cloudflare as a CDN to cache static assets.
+
+### PWA and authenticated caching
+
+Offline mode requires HTTPS in production. The service worker is served from
+`/sw.js` with root scope and loads `/sw-policy.js`. A valid public certificate is
+required; an HTTP origin or a certificate warning is not an acceptable PWA test
+environment. (`localhost` is treated as secure for desktop development but does
+not cover iPhone installation.)
+
+Both worker URLs must revalidate on every request so iOS can discover a new
+release. They must never receive an `immutable` directive or a long edge TTL.
+The manifest should also revalidate so install metadata changes are discovered.
+A suitable origin/CDN policy is:
+
+| Path | Recommended response policy |
+| --- | --- |
+| `/sw.js` | `Content-Type: text/javascript; charset=utf-8`, `Cache-Control: no-cache, must-revalidate`, no CDN cache override |
+| `/sw-policy.js` | `Content-Type: text/javascript; charset=utf-8`, `Cache-Control: no-cache, must-revalidate`, no CDN cache override |
+| `/manifest.webmanifest` | `Content-Type: application/manifest+json`, `Cache-Control: public, max-age=0, must-revalidate` |
+| `/_astro/*` | `Cache-Control: public, max-age=31536000, immutable` because filenames are content-hashed |
+| `/pwa/*`, `/favicon.svg`, `/logo.svg`, `/icons/*` | Revalidate or use a bounded TTL; these URLs are not content-hashed and must not be immutable |
+| Authenticated HTML and `/api/*` | Private/no shared caching; preserve the application's origin headers |
+
+`/sw.js` already sits at the origin root, so its default scope is `/`. A reverse
+proxy must not redirect it, rewrite it to HTML, require authentication for it,
+or strip service-worker-related response headers. The registration also uses
+`updateViaCache: none`, but that browser option is defense in depth rather than
+a replacement for correct CDN headers.
+
+Do not configure Cloudflare to publicly cache authenticated HTML routes. Those
+responses contain personal library data and are cached only in the signed-in
+user's browser by the service worker. Hashed `/_astro/*` assets and PWA icons may
+use different policies: only the hashed `/_astro/*` assets should be immutable.
+PWA icons have stable filenames and should revalidate or use a bounded TTL.
+
+When Cloudflare is used, create higher-priority cache rules for `/sw.js`,
+`/sw-policy.js`, and `/manifest.webmanifest` before the general static-asset
+rule. Do not use **Cache Everything** for signed-in routes. Purging Cloudflare is
+not a reliable service-worker update strategy; correct response headers must
+work for every deployment.
+
+Production verification should confirm:
+
+- `/manifest.webmanifest` returns the manifest content type and lists the 192px
+  and 512px PNG icons.
+- `/sw.js` and `/sw-policy.js` are served from the application origin without a
+  redirect, revalidate successfully, and do not include `immutable`.
+- The manifest revalidates, and only content-hashed `/_astro/*` responses use a
+  one-year immutable policy.
+- Authenticated requests to `/`, `/new`, `/series`, `/search`, and `/cache` reach
+  the origin and are not stored in a shared CDN cache.
+- Releasing a changed `/sw.js` produces a waiting worker, which activates on the
+  next app launch rather than interrupting the current session.
+
+Example header checks against the deployed origin:
+
+```bash
+curl -I https://comics.example/sw.js
+curl -I https://comics.example/sw-policy.js
+curl -I https://comics.example/manifest.webmanifest
+curl -I https://comics.example/_astro/<content-hashed-file>.js
+```
+
+Also inspect Cloudflare's cache-status header. Worker responses should be
+revalidated rather than served indefinitely from an edge cache, while the
+content-hashed asset may be a cache hit.

--- a/docs/OFFLINE.md
+++ b/docs/OFFLINE.md
@@ -1,0 +1,239 @@
+# Offline mode
+
+Offline mode combines an installable iOS PWA shell, cached app navigation,
+downloaded comic bundles, local progress, and a replayable mutation outbox. A
+user must complete one authenticated online launch before the app can work
+offline.
+
+## PWA installation and readiness
+
+The app includes a web manifest, Apple touch icon, standalone display metadata,
+and a root-scoped service worker. iOS does not expose a programmatic install
+prompt, so the app supports installation through Safari's **Add to Home Screen**
+action without showing its own prompt.
+
+After registration, the app asks the active service worker to cache the required
+root pages and their shell assets. The header reports **Preparing offline** until
+the service worker verifies all required entries, then reports **Ready offline**.
+It never infers readiness from registration alone. When the network is lost, the
+same compact status region changes to **Offline** regardless of readiness.
+
+The required root pages are:
+
+- `/`
+- `/new`
+- `/series`
+- `/search`
+- `/cache`
+
+## Document navigation policy
+
+Same-origin document requests use network-first handling. This includes both
+browser navigations and the HTML fetches made by Astro client transitions. A
+successful response replaces the cached copy; a network failure falls back to
+the most recently cached response for that exact URL, including its query
+string.
+
+Only successful `2xx`, non-redirected HTML responses can enter the document
+cache. The service worker never caches API, login, logout, OAuth, client metadata,
+redirect, non-HTML, or error responses. Shell assets under `/_astro`, `/icons`,
+and `/pwa` use cache-first handling after their first validated response. The
+warm-up follows JavaScript module imports and CSS asset references so a rendered
+root page does not depend on an uncached transitive chunk.
+
+Original `/covers/*` requests are network-first with read-only fallback to the
+downloaded-cover cache. Merely viewing a cover does not add it to offline storage;
+the comic download flow owns that decision.
+
+Redirects to an authentication route and the explicit
+`X-Comics-Auth-Invalid: true` response header are confirmed invalid-session
+signals. They trigger the same full purge as logout. Generic `401` or `403`
+responses do not, because they may describe a resource-level permission failure.
+
+## Service-worker updates
+
+A worker installed during an active reading session is left waiting. The client
+records that an update is pending and promotes the waiting worker on a later app
+launch, then reloads once under the new controller. Cache suffixes such as `v1`
+are schema versions, not release versions; ordinary deployments update the
+worker without discarding previously visited pages.
+
+## Storage ownership
+
+Offline data is split by purpose:
+
+- IndexedDB stores small, structured records that must be queried: downloaded
+  comic metadata, reading progress, queued mutations, and offline coordination
+  state.
+- Cache Storage stores response bodies and large binary data: CBZ archives,
+  covers, cached documents, and the application shell.
+
+The IndexedDB database is named `comics-offline`. Its schema is versioned and
+upgraded in place; application code must use the repositories exported from
+`src/lib/offline` rather than opening the database directly.
+
+| Store | Key | Purpose |
+| --- | --- | --- |
+| `comics` | `issueId` | Searchable issue and series metadata plus archive/cover cache keys |
+| `progress` | `issueId` | Local reading position and synchronization status |
+| `outbox` | `id` | Idempotent server mutations queued for later replay |
+| `offline-state` | `key` | Small state used by offline readiness and synchronization orchestration |
+
+The outbox has a unique `dedupeKey`. Writing a newer mutation with the same key
+replaces the older record, which prevents repeated progress updates for one issue
+from growing the queue without bound. `queueProgressUpdate()` writes reading
+progress and its corresponding mutation in one transaction. Add-to-library
+actions use `library:{seriesId}` as their dedupe key and retain one stable
+mutation id across retries.
+
+## Schema migrations
+
+`OFFLINE_DATABASE_VERSION` is the current database version. Every schema change
+must increment it and add a forward-only migration to `migrateDatabase()`. An
+upgrade must preserve records in existing stores. Browser tests cover a version
+1 to version 2 upgrade; new versions should add an equivalent upgrade fixture.
+
+Do not mutate or remove an old migration after it has shipped. Add a new version
+step instead.
+
+## Clearing offline data
+
+`clearOfflineData()` is the single purge boundary for local offline data. It
+closes and deletes the IndexedDB database, then removes every bucket listed in
+`KNOWN_OFFLINE_CACHE_NAMES`. It deliberately does not import UI or authentication
+code, so logout and confirmed session-invalid flows can call it directly.
+
+The current owned cache buckets are:
+
+- `comic-reader-v1`
+- `comic-reader-v2`
+- `comics-offline-assets-v1`
+- `comics-offline-pages-v1`
+- `comics-offline-covers-v1`
+
+When a new offline cache is introduced, add its name to
+`KNOWN_OFFLINE_CACHE_NAMES` in the same change. Unrelated origin caches are never
+deleted.
+
+## Security invariant
+
+An explicit logout or a server-confirmed invalid session must erase downloaded
+comics, cached pages, metadata, progress, and queued mutations. Being offline is
+not evidence that a session is invalid; network failures must not trigger a
+purge.
+
+## Downloaded comic bundle schema
+
+Downloaded comics use the `comic-reader-v2` Cache Storage bucket and the
+IndexedDB `comics` store. A complete bundle consists of:
+
+- a CBZ response at `/api/comic/{issueId}/download`;
+- a version 2 JSON metadata sidecar at
+  `/api/comic/{issueId}/cache-metadata`; and
+- a matching searchable `OfflineComicRecord` in IndexedDB.
+
+Cover bytes are best effort, live in `comics-offline-covers-v1`, and use the
+same-origin `/offline/comics/{issueId}/cover` Cache Storage key while preserving
+the original URL as source metadata. Metadata is valid only when it includes
+non-empty issue and series identifiers, a series name, an issue number, archive
+size and timestamp, cover state, and nullable previous/next references derived
+from the server's canonical series ordering. `isIssueCached()` reports only
+bundles with all three required records.
+
+Bundle commits write optional cover bytes first, required metadata second, the
+IndexedDB record third, and the archive last. If any required write fails, all
+records written for that attempt are rolled back. A cover failure instead stores
+`coverState: "pending"`, keeps the ThumbHash placeholder, and is retried on later
+access. Deleting a bundle removes its archive, sidecar, IndexedDB record, and
+cached cover.
+
+On first access, entries from `comic-reader-v1` are copied forward. Version 1
+sidecars with all required identity fields are upgraded to schema version 2 and
+backfilled into IndexedDB. Incomplete legacy archives stay readable for backward
+compatibility but are not advertised as complete offline bundles until current
+metadata is supplied.
+
+## Downloaded library and search
+
+The Cached Comics page reads the canonical `OfflineComicRecord` entries from
+IndexedDB rather than reconstructing its library from Cache Storage keys. It
+orders records by series name and natural issue number, displays only covers
+that have a downloaded cover cache key, and links each issue directly to its
+normal `/comic/{issueId}/read` route. Deletion still goes through the bundle
+deletion operation so the archive, sidecar, cover, and IndexedDB projection are
+removed together.
+
+The header search listens to both browser connectivity events and the PWA status
+event. While offline it does not call the library or ComicVine APIs. Instead it
+matches all query terms against downloaded issue and series metadata in
+IndexedDB, labels the result set as downloaded-only, and links results directly
+to the normal reader route. Online search keeps the existing library-first and
+ComicVine result sections. Both modes retain keyboard result navigation and
+explicit loading, empty, and error states.
+
+## Offline reader
+
+Reader navigations keep their normal `/comic/{issueId}/read` URL. If that
+navigation fails, the service worker returns the cached generic reader shell
+without redirecting the browser. The shell extracts the issue id from the
+current URL and requires a matching v2 metadata sidecar, IndexedDB comic record,
+and CBZ response before mounting the reader. Missing, partial, or corrupt saved
+copies produce an error with a route back to `/cache` rather than a blank page.
+
+The reader shell and its transitive JavaScript and CSS dependencies participate
+in warm-up and readiness checks. **Ready offline** therefore means a normal
+reader route can cold-launch after the PWA has been force-closed, provided that
+the requested comic bundle is complete.
+
+Reading position is stored immediately in the IndexedDB `progress` store using
+one-based page numbers. Online reader pages compare the server and local progress
+timestamps and restore the newest value; equal timestamps deterministically use
+the server value. The generic offline shell has no server value, so it restores
+valid local progress. Server replay is asynchronous; the reader does not depend
+on replay to preserve its local position.
+
+### Progress synchronization
+
+`saveReadingProgress()` atomically writes the local position and a deduplicated
+`progress` outbox mutation. Each mutation includes the current and total page,
+an ISO client timestamp, and an idempotency id. An equal or older local update
+does not replace a newer saved position.
+
+Pending progress is replayed serially by the shared mutation engine when an
+online app session starts, when the browser reports that it is back online, and
+when the installed app returns to the foreground. This intentionally uses
+foreground events rather than the Background Sync API. Successful updates mark
+local progress synced. A server-stale response supplies its authoritative page
+and timestamp, which replace the matching older local value before the mutation
+is settled; malformed conflict responses are retried. Network and 5xx failures
+stay pending with exponential retry metadata; permanent non-auth 4xx responses
+are marked failed. A 401 or 403 stops replay and invokes the same complete
+offline-data purge used for an invalid session.
+
+The server accepts a progress update only when its normalized `updated_at` is
+strictly newer than the issue's `progress_updated_at`. Equal timestamps are
+deterministically stale, regardless of arrival order, so retries and multiple
+devices cannot reverse a newer reading position.
+
+### Add-to-library synchronization
+
+Every add-to-library client uses `POST /api/library/add` with a JSON body
+containing `seriesId` and, for queued actions, `mutationId`. The client writes
+the outbox record before attempting an online request. Offline, network, and 5xx
+outcomes remain visibly pending; permanent non-auth 4xx outcomes are marked
+failed and can be retried. A 401 or 403 immediately invokes the full offline-data
+purge and is never converted into another queued action. Logout remains a direct
+security action and is not an outbox mutation.
+
+The shared replay engine posts the same mutation id until the action succeeds.
+Already-added responses count as success, and the API coalesces concurrent calls
+and remembers a bounded set of completed ids within the server process. The
+underlying Mylar operation is resource-idempotent by series id, so a replay after
+a server restart may repeat the request but cannot intentionally create a second
+series. The header badge reports the total pending and failed outbox actions; the
+series control separately shows added, pending, and retry states.
+
+Previous and next references come from the bundle's server-derived canonical
+ordering. The final-page action opens only the exact next saved issue. When a
+next reference exists but that bundle is unavailable, the reader shows
+**Next issue isn’t downloaded** and never skips ahead to a later issue.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,12 +1,22 @@
 # Testing
 
-This project uses Vitest for unit testing.
+This project uses Vitest for Node unit tests and Playwright-backed Chromium and
+WebKit browser tests.
 
 ## Running tests
 
 ```bash
 # Run all tests
-npx vitest run
+npm test
+
+# Run only Node tests
+npx vitest run --project node
+
+# Run only browser tests
+npx vitest run --project browser
+
+# Add WebKit to the browser project (release gate; requires local WebKit)
+PWA_WEBKIT=1 npx vitest run --project browser
 
 # Run tests in watch mode
 npx vitest
@@ -17,8 +27,12 @@ npx vitest run --coverage
 
 ## Test organization
 
-- **Test runner**: Vitest
-- **Location**: Colocate tests as `*.test.ts` next to the module under test
+- **Test runner**: Vitest, with Chromium supplied by Playwright for routine
+  browser tests and opt-in WebKit coverage for the iOS-oriented release gate
+- **Node tests**: Colocate as `*.test.ts` next to the module under test
+- **Browser tests**: Colocate as `*.browser.test.ts` or
+  `*.browser.test.tsx`; use these for IndexedDB, Cache Storage, rendering, and
+  other browser-only APIs
 - **Mocks**: Upstream fixtures go in `src/util/mocks/`
 
 ## Writing tests
@@ -30,6 +44,26 @@ src/util/formatter.ts
 src/util/formatter.test.ts
 ```
 
+Code that relies on real browser APIs should use a `.browser.test.ts` suffix.
+The offline storage tests intentionally exercise the browser's IndexedDB and
+Cache Storage implementations instead of replacing them with in-memory mocks.
+Every such test must delete the databases and cache buckets it creates in setup
+and teardown so tests remain isolated.
+
+Chromium remains the default so `npm test` works after an ordinary dependency
+install. WebKit is deliberately opt-in because Playwright browser binaries are
+installed separately and may not exist on every developer or CI machine. To run
+the iOS-oriented browser gate:
+
+```bash
+npx playwright install webkit
+PWA_WEBKIT=1 npx vitest run --project browser
+```
+
+This runs the browser suite in both Chromium and WebKit. It is engine coverage,
+not a substitute for an installed PWA on physical iOS: desktop WebKit does not
+reproduce iOS storage eviction, home-screen installation, or process suspension.
+
 ### Mock data
 
 Mock data for external APIs (Mylar, Comic Vine) should be placed in `src/util/mocks/` for reuse across tests.
@@ -38,9 +72,106 @@ Existing mocks:
 - `comicvineIssues.mock.ts`: Sample Comic Vine issue data
 - `comicvineVolume.mock.ts`: Sample Comic Vine volume data
 
-## Current test coverage
+## Offline storage checks
 
-Test files in the codebase:
-- `src/data/comicvine/comicvine.test.ts`
-- `src/data/elastic/elastic.test.ts`
-- `src/util/formatter.test.ts`
+When changing the IndexedDB schema or an owned cache name, run:
+
+```bash
+npx vitest run --project browser src/lib/offline
+npm run type:check:tsc
+```
+
+Schema changes require an upgrade test that starts from the previous database
+version and proves existing records survive. Purge tests must verify both that
+all owned storage is removed and that unrelated Cache Storage buckets remain.
+
+## PWA checks
+
+The service-worker cache policy is kept in `public/sw-policy.js` so the worker
+and its Node tests exercise the same rules. After changing the manifest,
+service-worker lifecycle, navigation policy, or header status, run:
+
+```bash
+npx vitest run --project node src/lib/pwa
+npx vitest run --project browser src/lib/pwa
+npm run build
+PWA_BUILD_SMOKE=1 npx vitest run --project node tests/pwa-build-smoke.test.ts
+```
+
+`tests/pwa-artifacts.test.ts` checks the source manifest, icon dimensions,
+precache inputs, layout metadata, and worker lifecycle messages during normal
+`npm test`. The opt-in build smoke must run after `npm run build`; it fails if
+the server entry or required PWA files are absent from `dist`, and confirms that
+the built worker files are the versions that were reviewed.
+
+## Real-iPhone release checklist
+
+Run this checklist in the production-like HTTPS environment, using an iPhone on
+the oldest iOS version the release supports. Start with the site's Safari data
+and any existing home-screen app removed.
+
+### Install and first warm
+
+1. Open the site in Safari, sign in, use **Share → Add to Home Screen**, and
+   launch the installed app from its icon.
+2. Confirm it opens in standalone mode with the expected name, icon, theme
+   color, and safe-area layout. The app does not show its own install prompt.
+3. Confirm the header starts at **Preparing offline** and does not report
+   **Ready offline** early.
+4. Keep the app online until it shows **Ready offline**. Visit `/`, `/new`,
+   `/series`, `/search`, and `/cache`, plus another navigated series page.
+5. Download at least two issues from one series, leaving a deliberate issue gap.
+   Confirm their cover and metadata appear under Cached Comics.
+
+### Cold offline launch
+
+1. Force-close the PWA from the app switcher, enable airplane mode, and launch
+   it again from the home-screen icon. Do not prime it in Safari first.
+2. Confirm the normal shell renders, the header clearly says **Offline**, and
+   the five root pages plus the previously visited series page open from their
+   saved copies.
+3. Open Cached Comics and confirm saved covers render (or the documented
+   placeholder where a cover download failed), issue ordering is correct, and a
+   saved issue opens at its normal `/comic/{id}/read` URL.
+4. Read several pages, force-close, relaunch offline, and confirm reading resumes
+   from local progress. At the end of the issue, verify a downloaded adjacent
+   issue opens and the deliberate gap says **Next issue isn't downloaded**.
+5. Open header search, confirm it is labelled as offline/downloaded-only, find a
+   downloaded issue by series and issue metadata, and verify no online-only
+   ComicVine results appear.
+
+### Reconnect and replay
+
+1. While still offline, change reading progress and perform an add-to-library
+   action. Confirm the optimistic pending state/count is visible.
+2. Restore connectivity, foreground or relaunch the PWA, and confirm both queued
+   actions replay without requiring background sync.
+3. Verify the pending count clears. On another signed-in device, create a newer
+   reading-progress timestamp and confirm the newest timestamp wins rather than
+   blindly accepting the offline value.
+
+### Worker update on next launch
+
+1. Keep the installed PWA open on the current release, deploy a build with a
+   changed `sw.js`, and allow the browser to detect the update.
+2. Confirm the active reading session is not reloaded or interrupted.
+3. Force-close and relaunch the PWA. Confirm the waiting worker activates, the
+   app reloads at most once under the new controller, and offline readiness is
+   re-established before **Ready offline** appears.
+
+### Purge, interruption, and best-effort storage
+
+1. Start another comic download, interrupt connectivity or force-close before
+   it completes, then relaunch. Confirm no partial issue is advertised in Cached
+   Comics and a later download can succeed.
+2. Remove a downloaded cover response (or reproduce a failed cover request) and
+   confirm the readable issue remains, a placeholder appears, and a later online
+   access can retry the cover.
+3. Use Safari's website-data controls to evict the site's local data. Relaunch
+   and confirm the app degrades to an empty/not-ready state without presenting
+   evicted comics as available. Re-prime and redownload successfully.
+4. Download a comic and queue an action again, then explicitly log out. Confirm
+   cached pages, comics, covers, metadata, progress, and pending actions are all
+   gone.
+5. Sign in again, cache data, then invalidate the server session. On the next
+   confirmed invalid-session response, confirm the same full purge occurs.

--- a/tests/pwa-artifacts.test.ts
+++ b/tests/pwa-artifacts.test.ts
@@ -1,0 +1,136 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runInNewContext, Script } from "node:vm";
+import { describe, expect, test } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const publicRoot = resolve(repositoryRoot, "public");
+
+function readText(path: string): string {
+	return readFileSync(resolve(repositoryRoot, path), "utf8");
+}
+
+function pngDimensions(path: string): { height: number; width: number } {
+	const png = readFileSync(path);
+	expect(png.subarray(1, 4).toString("ascii")).toBe("PNG");
+	expect(png.subarray(12, 16).toString("ascii")).toBe("IHDR");
+	return { width: png.readUInt32BE(16), height: png.readUInt32BE(20) };
+}
+
+type ManifestIcon = {
+	purpose: string;
+	sizes: string;
+	src: string;
+	type: string;
+};
+
+type PwaManifest = {
+	background_color: string;
+	display: string;
+	icons: ManifestIcon[];
+	name: string;
+	scope: string;
+	short_name: string;
+	start_url: string;
+	theme_color: string;
+};
+
+type ServiceWorkerPolicy = {
+	READER_SHELL_PATH: string;
+	ROOT_PAGES: string[];
+	SHELL_PAGES: string[];
+	STATIC_ASSETS: string[];
+};
+
+describe("PWA release artifacts", () => {
+	test("ships a root-scoped standalone manifest with real iOS-sized PNGs", () => {
+		const manifest = JSON.parse(
+			readText("public/manifest.webmanifest"),
+		) as PwaManifest;
+
+		expect(manifest).toMatchObject({
+			name: "Sardines Reading Comics",
+			short_name: "Sardines",
+			start_url: "/",
+			scope: "/",
+			display: "standalone",
+			background_color: "#0f172a",
+			theme_color: "#0f172a",
+		});
+
+		for (const size of [192, 512]) {
+			const icon = manifest.icons.find(
+				(candidate) => candidate.sizes === `${size}x${size}`,
+			);
+			expect(icon).toMatchObject({
+				type: "image/png",
+				purpose: expect.stringContaining("any"),
+			});
+			const iconPath = resolve(publicRoot, icon?.src.replace(/^\//, "") ?? "");
+			expect(existsSync(iconPath)).toBe(true);
+			expect(pngDimensions(iconPath)).toEqual({ width: size, height: size });
+		}
+
+		const appleTouchIcon = resolve(publicRoot, "pwa/icon-180.png");
+		expect(pngDimensions(appleTouchIcon)).toEqual({ width: 180, height: 180 });
+	});
+
+	test("keeps service-worker policy parseable and every precached asset present", () => {
+		const policySource = readText("public/sw-policy.js");
+		const context: {
+			ComicsPwaPolicy?: ServiceWorkerPolicy;
+			URL: typeof URL;
+		} = { URL };
+		runInNewContext(policySource, context);
+		const policy = context.ComicsPwaPolicy;
+		expect(policy).toBeDefined();
+		expect(policy?.ROOT_PAGES).toEqual([
+			"/",
+			"/new",
+			"/series",
+			"/search",
+			"/cache",
+		]);
+		expect(policy?.READER_SHELL_PATH).toBe("/offline/reader");
+		expect(policy?.SHELL_PAGES).toEqual([
+			...(policy?.ROOT_PAGES ?? []),
+			"/offline/reader",
+		]);
+
+		for (const asset of policy?.STATIC_ASSETS ?? []) {
+			expect(
+				existsSync(resolve(publicRoot, asset.replace(/^\//, ""))),
+				`Missing service-worker asset ${asset}`,
+			).toBe(true);
+		}
+	});
+
+	test("ships a parseable worker with warm, readiness, update, and purge paths", () => {
+		const worker = readText("public/sw.js");
+		expect(() => new Script(worker, { filename: "sw.js" })).not.toThrow();
+		expect(worker).toContain('importScripts("/sw-policy.js")');
+		expect(worker).toContain('message.type === "WARM_OFFLINE"');
+		expect(worker).toContain('message.type === "GET_OFFLINE_STATUS"');
+		expect(worker).toContain('message.type === "ACTIVATE_UPDATE"');
+		expect(worker).toContain('message.type === "PURGE_OFFLINE"');
+		expect(worker).toContain("SHELL_PAGES.map");
+		expect(worker).toContain("KNOWN_OFFLINE_CACHES.map");
+		expect(worker).toContain("deleteDatabase(OFFLINE_DATABASE)");
+	});
+
+	test("includes install and lifecycle metadata in both application layouts", () => {
+		for (const layout of [
+			"src/layouts/Layout.astro",
+			"src/layouts/ReaderLayout.astro",
+		]) {
+			const source = readText(layout);
+			expect(source).toContain('rel="manifest" href="/manifest.webmanifest"');
+			expect(source).toContain(
+				'rel="apple-touch-icon" href="/pwa/icon-180.png"',
+			);
+			expect(source).toContain('name="apple-mobile-web-app-capable"');
+			expect(source).toContain("void initialisePwa()");
+		}
+	});
+});

--- a/tests/pwa-build-smoke.test.ts
+++ b/tests/pwa-build-smoke.test.ts
@@ -1,0 +1,47 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const builtClientRoot = resolve(repositoryRoot, "dist/client");
+const runBuildSmoke = process.env.PWA_BUILD_SMOKE === "1";
+
+function built(path: string): string {
+	return resolve(builtClientRoot, path);
+}
+
+describe.skipIf(!runBuildSmoke)("built PWA smoke gate", () => {
+	test("copies all root-scoped PWA files into the client build", () => {
+		for (const path of [
+			"manifest.webmanifest",
+			"sw.js",
+			"sw-policy.js",
+			"pwa/icon-180.png",
+			"pwa/icon-192.png",
+			"pwa/icon-512.png",
+		]) {
+			expect(existsSync(built(path)), `Missing built artifact /${path}`).toBe(
+				true,
+			);
+		}
+	});
+
+	test("keeps built worker sources identical to the reviewed public files", () => {
+		for (const path of ["manifest.webmanifest", "sw.js", "sw-policy.js"]) {
+			expect(readFileSync(built(path))).toEqual(
+				readFileSync(resolve(repositoryRoot, "public", path)),
+			);
+		}
+	});
+
+	test("emits hashed client assets and the Node server entry", () => {
+		const astroAssets = readdirSync(built("_astro"));
+		expect(
+			astroAssets.some((name) => /[_-][A-Za-z0-9_-]{6,}\./.test(name)),
+		).toBe(true);
+		expect(existsSync(resolve(repositoryRoot, "dist/server/entry.mjs"))).toBe(
+			true,
+		);
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,12 @@ import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "vitest/config";
 
 const srcRoot = fileURLToPath(new URL("src/", import.meta.url));
+const runWebKit = process.env.PWA_WEBKIT === "1";
+
+const browserInstances: Array<{ browser: "chromium" | "webkit" }> = [
+	{ browser: "chromium" },
+];
+if (runWebKit) browserInstances.push({ browser: "webkit" });
 
 const aliases = [
 	{ find: /^@components\/(.*)/, replacement: `${srcRoot}components/$1` },
@@ -21,7 +27,7 @@ export default defineConfig({
 				test: {
 					name: "node",
 					environment: "node",
-					include: ["src/**/*.test.ts"],
+					include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
 					exclude: ["src/**/*.browser.test.{ts,tsx}"],
 				},
 			},
@@ -44,10 +50,11 @@ export default defineConfig({
 					name: "browser",
 					include: ["src/**/*.browser.test.{ts,tsx}"],
 					browser: {
+						api: { host: "127.0.0.1" },
 						enabled: true,
 						provider: playwright(),
 						headless: true,
-						instances: [{ browser: "chromium" }],
+						instances: browserInstances,
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

- keep Chromium as the routine browser-test target and add opt-in WebKit coverage for the iOS-oriented release gate
- verify manifest metadata, real PNG icon dimensions, shell/static precache inputs, worker syntax, readiness, update, and purge paths from source artifacts
- add a post-build smoke gate for emitted PWA files, hashed client assets, and the Node server entry
- document the complete offline storage, bundle, navigation, reader, search, progress, library-action, update, and purge contracts
- add HTTPS, service-worker revalidation, authenticated HTML, and Cloudflare/CDN deployment guidance
- provide a physical-iPhone checklist covering install, cold offline launch, reconnect/replay, next-launch worker activation, interrupted downloads, eviction, and logout/session purge

## Why

Desktop engine tests cannot prove iOS home-screen installation, process suspension, storage eviction, or deployment cache behavior. This final layer makes the release process explicit and adds automated checks for every artifact that can be verified before the real-device gate.

## Stack

- **9 of 9**
- Depends on #259
- Base: `codex/offline-pwa-shell`
- Final branch: `codex/offline-ios-hardening`

## Validation

- `npm test` — 345 tests passed, 3 expected skips
- `npm run type:check:tsc`
- `npm run type:check`
- `npm run lint`
- `npm run build`
- `PWA_BUILD_SMOKE=1 npx vitest run --project node tests/pwa-build-smoke.test.ts` — 3 tests passed
- `PWA_WEBKIT=1 npx vitest run --project browser` — 180 Chromium/WebKit tests passed
